### PR TITLE
Implement data gaps handling with two-layer validation

### DIFF
--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -1,6 +1,7 @@
 # Architecture Review Findings & Action Plan
 
 *Created: 2026-02-22 | Session: review-architecture-changes-GWIjK*
+*Updated: 2026-02-24 | Data gaps handling implemented (Asset NaN rejection, graceful trade failure, zero income on NaN, pre-commit mypy fixes)*
 *Context: Full codebase review for production readiness — decades of daily data, AI-written strategies*
 
 **After completion items will be deleted and can be recovered from git commit history.**
@@ -270,38 +271,6 @@ what severity to assign to recovered vs fatal errors.
 Move computation outside the `for symbol in symbols` loop.
 Minor optimization but easy fix.
 
-### Data gaps: validate at init, graceful at trade time
-**Files:** `pyfolium/core.py` (Asset.__init__, Portfolio.buy_asset, Portfolio.sell_asset, Portfolio.collect_income),
-`pyfolium/strategy.py` (BaseStrategy.execute_trades)
-**Problem:** No validation against NaN values in price data. Two distinct failure modes:
-1. Asset created with NaN prices within its own declared date range — data corruption that
-   passes all current checks silently.
-2. Strategy trades an asset at a period outside its data range — price_matrix returns NaN
-   after universe alignment via `reindex()`. Trade silently produces NaN cash flows.
-
-**Fix (two layers, different philosophies):**
-1. **Asset.__init__ (data quality gate):** Reject price series containing NaN:
-   `if self.data[self.price_column].isna().any(): raise ValueError(...)`
-   Users must provide clean data for the periods they declare. Gaps from weekends, holidays,
-   or different asset date ranges are handled by the universe alignment — not by allowing
-   NaN in the source data.
-
-2. **Portfolio.buy_asset / sell_asset (graceful failure):** Guard price lookup:
-   `price = ...; if pd.isna(price): raise ValueError(f"Cannot trade {symbol} at {period}: price is NaN")`
-   This ValueError is already caught by `BaseStrategy.execute_trades()`, which records
-   the trade with `success=False` in `trades_df`. The strategy continues executing.
-   **Also:** `execute_trades` currently only catches `ValueError`. Add `KeyError` to the
-   except clause — a price lookup on a period outside the asset's range may raise KeyError
-   instead of returning NaN depending on the access path.
-
-3. **Portfolio.collect_income:** Treat NaN income as zero income (nothing to collect where
-   there is no data). Not an error — just skip silently.
-
-**Test:** Create asset with NaN gap, verify Asset rejects it at construction. Create universe
-where asset A starts later than asset B, attempt buy on A before its start date, verify trade
-returns `success=False` in `trades_df` rather than crashing.
-**Design doc update:** `DESIGN.md` "Data Integrity" section — already updated.
-
 ### Tax/fee config extensibility (template pattern)
 **Files:** `pyfolium/core.py` (TaxConfig, FeeConfig, Portfolio.sell_asset, Portfolio.collect_income)
 **Problem:** TaxConfig is purely declarative — rates and a strategy name string. All tax
@@ -375,7 +344,6 @@ clone() docstring in `core.py`.
 
 Recommended sequence:
 
-3. **Data gaps** — Asset NaN rejection at init + trade-time graceful failure via success=False
 4. **Strategy start conditions** — `initial_cash` + `start_period` on BaseStrategy, runner sync. High user-impact, changes the primary API surface.
 5. **P2-5** (total_value property) — Small, used by everything downstream
 6. **P2-6** (trade failure warnings) — Small, important for AI strategies

--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -1,7 +1,8 @@
 # Architecture Review Findings & Action Plan
 
 *Created: 2026-02-22 | Session: review-architecture-changes-GWIjK*
-*Updated: 2026-02-24 | Data gaps handling implemented + refactored per PR review (universe matrices as sole runtime data interface, removed get_price_at/get_income_at, pre-commit mypy fixes)*
+*Updated: 2026-02-24 | Data gaps handling implemented + refactored per PR review (universe matrices as sole runtime data interface, removed get_price_at/get_income_at)*
+*Updated: 2026-02-28 | Rebased onto development; mypy → pyright (cast() for reportAssignmentType, warnings demoted in pyproject.toml for remaining pandas-stubs false-positives)*
 *Context: Full codebase review for production readiness — decades of daily data, AI-written strategies*
 
 **After completion items will be deleted and can be recovered from git commit history.**

--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -1,7 +1,7 @@
 # Architecture Review Findings & Action Plan
 
 *Created: 2026-02-22 | Session: review-architecture-changes-GWIjK*
-*Updated: 2026-02-24 | Data gaps handling implemented (Asset NaN rejection, graceful trade failure, zero income on NaN, pre-commit mypy fixes)*
+*Updated: 2026-02-24 | Data gaps handling implemented + refactored per PR review (universe matrices as sole runtime data interface, removed get_price_at/get_income_at, pre-commit mypy fixes)*
 *Context: Full codebase review for production readiness — decades of daily data, AI-written strategies*
 
 **After completion items will be deleted and can be recovered from git commit history.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The project name is a German pun: "Hätte hätte Fahrradkette" (roughly translat
 - Activate environment manually: `source .venv/bin/activate`
 - Python version: 3.12+
 
-**Note:** After running `setup-dev`, pre-commit hooks will automatically run ruff and mypy on every commit. Use `uv run pre-commit run --all-files` rather than `uv run mypy pyfolium/` directly — pre-commit uses its own isolated environment with pinned package versions that matches CI, preventing version drift between local checks and CI.
+**Note:** After running `setup-dev`, pre-commit hooks will automatically run ruff and pyright on every commit. Use `uv run pre-commit run --all-files` to run all hooks locally.
 
 ### Testing
 - Run all tests: `uv run pytest`
@@ -31,11 +31,12 @@ The project name is a German pun: "Hätte hätte Fahrradkette" (roughly translat
 - Format and fix: `uv run ruff format .` (replaces black)
 - Lint and fix: `uv run ruff check --fix .` (replaces flake8 and isort)
 - Lint only: `uv run ruff check .`
-- Type checking: `uv run mypy pyfolium/`
+- Type checking: `uv run pyright pyfolium/`
 - Run all checks: `uv run pre-commit run --all-files`
 
 All code quality tools configured in `pyproject.toml`:
 - **Ruff**: Extremely fast linter and formatter (replaces black, isort, flake8)
+- **Pyright**: Static type checker in `standard` mode; pandas-stubs false-positives on `Period`/`Scalar` demoted to warnings (non-blocking) in `[tool.pyright]`
 - Line length: 88 characters
 - Import sorting: isort-compatible, with pyfolium as first-party
 - Linting rules: pycodestyle, pyflakes, pep8-naming, pyupgrade, flake8-bugbear, and more

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The project name is a German pun: "Hätte hätte Fahrradkette" (roughly translat
 - Activate environment manually: `source .venv/bin/activate`
 - Python version: 3.12+
 
-**Note:** After running `setup-dev`, pre-commit hooks will automatically run ruff on every commit.
+**Note:** After running `setup-dev`, pre-commit hooks will automatically run ruff and mypy on every commit. Use `uv run pre-commit run --all-files` rather than `uv run mypy pyfolium/` directly — pre-commit uses its own isolated environment with pinned package versions that matches CI, preventing version drift between local checks and CI.
 
 ### Testing
 - Run all tests: `uv run pytest`
@@ -62,9 +62,10 @@ This state machine is enforced via `PortfolioState` enum to prevent operations i
 
 **Asset** (`pyfolium/core.py`): Individual financial instrument
 - Requires DataFrame with PeriodIndex at specified frequency
-- Must have a price column; income column optional (defaults to 0)
+- Must have a price column with no NaN values; income column optional (defaults to 0)
 - Self-registers with parent AssetUniverse on initialization
 - Validates index is monotonic and matches universe frequency
+- Rejects NaN prices at construction (data quality gate)
 
 **Portfolio** (`pyfolium/core.py`): The core backtesting engine
 - Tracks `cash`, `tax_owed`, `holdings` (positions over time)
@@ -146,6 +147,7 @@ strategies/         # User-defined strategies (empty, for users to populate)
 ## Current State
 
 Recent features:
+- **Data gaps handling**: Asset rejects NaN prices at construction; trades on out-of-range periods fail gracefully via `success=False` in `trades_df`; NaN income treated as zero
 - **BacktestRunner**: Automated simulation with hooks and progress reporting (370 LOC)
 - **Portfolio.clone()**: Deep copy for strategy comparison and optimization
 - **Pydantic validation**: TaxConfig and FeeConfig with automatic validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,13 @@ This state machine is enforced via `PortfolioState` enum to prevent operations i
 - All assets must have matching `data_frequency` (e.g., 'D' for daily, 'M' for monthly)
 - Automatically updates matrices when assets are added
 
-**Asset** (`pyfolium/core.py`): Individual financial instrument
+**Asset** (`pyfolium/core.py`): Validated data container for a financial instrument
 - Requires DataFrame with PeriodIndex at specified frequency
 - Must have a price column with no NaN values; income column optional (defaults to 0)
 - Self-registers with parent AssetUniverse on initialization
 - Validates index is monotonic and matches universe frequency
 - Rejects NaN prices at construction (data quality gate)
+- Runtime price/income queries go through `universe.price_matrix`/`income_matrix`, not Asset methods
 
 **Portfolio** (`pyfolium/core.py`): The core backtesting engine
 - Tracks `cash`, `tax_owed`, `holdings` (positions over time)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -189,13 +189,15 @@ When the AssetUniverse aligns assets with different date ranges via `reindex()`,
 
 If a strategy attempts a trade at a period where the price is NaN, the trade **fails gracefully** rather than crashing the backtest:
 
-- `buy_asset()` / `sell_asset()` detect the NaN price and raise a `ValueError`.
-- BaseStrategy's `execute_trades()` catches this and records the trade with `success=False` in `trades_df`.
+- `buy_asset()` / `sell_asset()` look up the price via `universe.price_matrix.loc[period, symbol]`. For out-of-range periods this returns NaN.
+- The NaN guard raises `ValueError`, which `execute_trades()` catches and records as `success=False` in `trades_df`.
 - The strategy continues executing. It can handle the failure by:
-  1. Checking data availability *before* placing a trade.
+  1. Checking data availability *before* placing a trade (e.g., `pd.isna(universe.price_matrix.loc[period, symbol])`).
   2. Inspecting `trades_df` for failed trades after the period.
 
 This means a strategy that blindly trades every period won't crash — it will accumulate `success=False` entries that the user can inspect. A strategy that checks prices first will never encounter the failure at all.
+
+Note: the Asset class is a validated data container that feeds the universe at construction time. At runtime, all price and income queries go through `universe.price_matrix` and `universe.income_matrix` — not through individual Asset methods. This ensures a single, consistent data access path with predictable NaN behavior for out-of-range periods.
 
 ### Income gaps
 
@@ -207,7 +209,7 @@ Strategies are subclasses of `BaseStrategy` with one required method: `get_trade
 
 The design is deliberately minimal:
 
-- **No market data API** — the strategy accesses `self.portfolio` and its `asset_universe` directly. You have all the data; decide what to do with it.
+- **No market data API** — the strategy accesses prices and income via `self.asset_universe.price_matrix` and `self.asset_universe.income_matrix`. These are aligned DataFrames indexed by period and symbol. You have all the data; decide what to do with it.
 - **No order types** — trades execute at the current period's price. Limit orders, stop losses, and slippage models are out of scope (they belong in a more complex execution simulation).
 - **No position sizing helpers** — compute your own quantities. This avoids baking in assumptions about how sizing should work.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ uv run ruff format .
 uv run ruff check --fix .
 
 # Type check
-uv run mypy pyfolium/
+uv run pyright pyfolium/
 
 # Run all pre-commit checks manually
 uv run pre-commit run --all-files

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from enum import Enum
-from math import isnan
 
 import pandas as pd
 from pydantic import BaseModel, Field, field_validator
@@ -156,42 +155,6 @@ class Asset:
     @property
     def income(self):
         return self.data[self.income_column]
-
-    def get_price_at(self, period: pd.Period, precise: bool = True) -> float:
-        """
-        Get the price of the asset at the given period
-
-        Args:
-            period (pd.Period): The period to get the price for
-            precise (bool, optional): Whether to get the price
-                for the exact period or the asof value
-
-        Returns:
-            float: The price of the asset at the given period
-        """
-        # if it's before the start date raise an key error
-        if period < self.start_time:
-            raise KeyError("Data not available before the start date")
-
-        if not precise:
-            # Return the last available price before the period
-            return float(self.price.asof(period))
-
-        return float(self.price[period])
-
-    def get_income_at(self, period: pd.Period) -> float:
-        """
-        Get the income of the asset at the given period
-
-        Args:
-            period (pd.Period): The period to get the price for
-
-        Returns:
-            float: The income of the asset at the given period.
-                Will return `0.0` if there was `nan` income.
-        """
-        value = float(self.income[period])
-        return 0.0 if isnan(value) else value
 
 
 class AssetUniverse:
@@ -673,11 +636,15 @@ class Portfolio:
         if quantity <= 0:
             raise ValueError("Quantity must be positive")
 
-        price = self.asset_universe.assets[symbol].get_price_at(self.current_period)
-        if pd.isna(price):
+        raw_price = self.asset_universe.price_matrix.loc[
+            self.current_period, symbol  # type: ignore[index]
+        ]
+        if pd.isna(raw_price):
             raise ValueError(
-                f"Cannot buy {symbol} at {self.current_period}: price is NaN"
+                f"Cannot buy {symbol} at {self.current_period}: "
+                "no price data for this period"
             )
+        price = float(raw_price)  # type: ignore[arg-type]
         fee = self.fee_config.calculate_fee(quantity * price)
         cost_basis_per_share = price + fee / quantity
         transaction_amount = -(quantity * price + fee)
@@ -737,11 +704,15 @@ class Portfolio:
                 f"{current_holding_quantity} for symbol {symbol}."
             )
         quantity_to_sell = quantity
-        price = self.asset_universe.assets[symbol].get_price_at(self.current_period)
-        if pd.isna(price):
+        raw_price = self.asset_universe.price_matrix.loc[
+            self.current_period, symbol  # type: ignore[index]
+        ]
+        if pd.isna(raw_price):
             raise ValueError(
-                f"Cannot sell {symbol} at {self.current_period}: price is NaN"
+                f"Cannot sell {symbol} at {self.current_period}: "
+                "no price data for this period"
             )
+        price = float(raw_price)  # type: ignore[arg-type]
         fee = self.fee_config.calculate_fee(quantity * price)
         cost_basis_per_share = price - fee / quantity
 
@@ -753,16 +724,16 @@ class Portfolio:
             - self.tax_config.long_term_holding_period
         ).to_period(self.asset_universe.data_frequency)
 
-        # sell tax lots until we run out of qunatity_to_sell
+        # sell tax lots until we run out of quantity_to_sell
         for lot in tax_lots.index:
             # get the basic transaction info
-            lot_quantity_remaining = self.transactions.loc[
-                lot, "lot_quantity_remaining"
-            ]
-            transaction_period = self.transactions.loc[lot, "period"]
-            lot_cost_basis_per_share = self.transactions.loc[
-                lot, "cost_basis_per_share"
-            ]
+            lot_quantity_remaining = float(
+                self.transactions.loc[lot, "lot_quantity_remaining"]
+            )
+            transaction_period: pd.Period = self.transactions.loc[lot, "period"]
+            lot_cost_basis_per_share = float(
+                self.transactions.loc[lot, "cost_basis_per_share"]
+            )
 
             lot_quantity_sold = min(quantity_to_sell, lot_quantity_remaining)
             lot_gains = lot_quantity_sold * (

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from enum import Enum
+from typing import cast
 
 import pandas as pd
 from pydantic import BaseModel, Field, field_validator
@@ -730,7 +731,7 @@ class Portfolio:
             lot_quantity_remaining = float(
                 self.transactions.loc[lot, "lot_quantity_remaining"]
             )
-            transaction_period: pd.Period = self.transactions.loc[lot, "period"]
+            transaction_period = cast(pd.Period, self.transactions.loc[lot, "period"])
             lot_cost_basis_per_share = float(
                 self.transactions.loc[lot, "cost_basis_per_share"]
             )

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -127,6 +127,13 @@ class Asset:
                 "is not strictly monotonic"
             )
 
+        if self.data[self.price_column].isna().any():
+            raise ValueError(
+                f"Price column '{self.price_column}' of asset '{self.symbol}' "
+                "contains NaN values. Provide clean price data for all declared "
+                "periods."
+            )
+
         if income_column:
             if income_column not in self.data.columns:
                 raise ValueError(f"Column {income_column} not in data")
@@ -523,7 +530,7 @@ class Portfolio:
             self.transactions["period"] == self.current_period
         ]
 
-        self.history.loc[self.current_period] = {  # type: ignore
+        self.history.loc[self.current_period] = {
             "cash": self.cash,
             "tax_owed": self.tax_owed,
             "long_term_gains_in_period": period_transactions["long_term_gains"].sum(),
@@ -531,7 +538,7 @@ class Portfolio:
             "taxes_paid_in_period": period_transactions["tax_paid"].sum(),
         }
 
-        self._states[self.current_period] = PortfolioState.DONE
+        self._states[self.current_period] = PortfolioState.DONE  # type: ignore[call-overload]
 
     def collect_income(self):
         """Collect all the income for the current period.
@@ -552,15 +559,18 @@ class Portfolio:
         """
         self._check_state(PortfolioState.COLLECT_INCOME)
 
+        income_this_period = (
+            self.asset_universe.income_matrix.loc[self.current_period].fillna(0)  # type: ignore[call-overload]
+        )
         symbols = (
             self.holdings.loc[self.current_period]  # type: ignore[call-overload]
-            * self.asset_universe.income_matrix.loc[self.current_period]  # type: ignore[call-overload]
+            * income_this_period
         )
         symbols = self.holdings.columns[symbols != 0]
 
         for symbol in symbols:
-            # get the income
-            income = self.asset_universe.income_matrix.loc[self.current_period, symbol]  # type: ignore
+            # get the income — NaN means no data for this period, treat as zero
+            income = income_this_period[symbol]
 
             # filter transactions to this symbol only buy
             tax_lots = self.transactions[
@@ -612,7 +622,7 @@ class Portfolio:
             self.tax_owed += tax_liability
             self.cash += transaction_amount
 
-        self._states[self.current_period] = PortfolioState.TRANSACT
+        self._states[self.current_period] = PortfolioState.TRANSACT  # type: ignore[call-overload]
 
     def move_cash(self, amount: float):
         """Move cash in or out of the portfolio.
@@ -664,6 +674,10 @@ class Portfolio:
             raise ValueError("Quantity must be positive")
 
         price = self.asset_universe.assets[symbol].get_price_at(self.current_period)
+        if pd.isna(price):
+            raise ValueError(
+                f"Cannot buy {symbol} at {self.current_period}: price is NaN"
+            )
         fee = self.fee_config.calculate_fee(quantity * price)
         cost_basis_per_share = price + fee / quantity
         transaction_amount = -(quantity * price + fee)
@@ -679,7 +693,7 @@ class Portfolio:
             transaction_amount=transaction_amount,
         )
 
-        self.holdings.loc[self.current_period, symbol] += quantity  # type: ignore[index]
+        self.holdings.loc[self.current_period, symbol] += quantity  # type: ignore[index, operator]
 
         self.cash += transaction_amount
 
@@ -724,6 +738,10 @@ class Portfolio:
             )
         quantity_to_sell = quantity
         price = self.asset_universe.assets[symbol].get_price_at(self.current_period)
+        if pd.isna(price):
+            raise ValueError(
+                f"Cannot sell {symbol} at {self.current_period}: price is NaN"
+            )
         fee = self.fee_config.calculate_fee(quantity * price)
         cost_basis_per_share = price - fee / quantity
 
@@ -791,7 +809,7 @@ class Portfolio:
             transaction_amount=transaction_amount,
         )
 
-        self.holdings.loc[self.current_period, symbol] -= quantity  # type: ignore[index]
+        self.holdings.loc[self.current_period, symbol] -= quantity  # type: ignore[index, operator]
 
         self.cash += transaction_amount
         self.tax_owed += tax_liability

--- a/pyfolium/simulation.py
+++ b/pyfolium/simulation.py
@@ -285,7 +285,7 @@ class BacktestRunner:
                 # If collect_income didn't finish, force to TRANSACT so that
                 # update_history() can still run and record actual portfolio state.
                 if current_state == PortfolioState.COLLECT_INCOME:
-                    self.portfolio._states[self.current_period] = (
+                    self.portfolio._states[self.current_period] = (  # type: ignore[call-overload]
                         PortfolioState.TRANSACT
                     )
 

--- a/pyfolium/strategy.py
+++ b/pyfolium/strategy.py
@@ -71,7 +71,7 @@ class BaseStrategy(ABC):
                 elif quantity < 0:
                     self.portfolio.sell_asset(symbol, abs(quantity))
                     self._record_trade(symbol, quantity, quantity)
-            except ValueError:
+            except (ValueError, KeyError):
                 self._record_trade(symbol, quantity, 0, success=False)
                 continue
 

--- a/pyfolium/strategy.py
+++ b/pyfolium/strategy.py
@@ -71,7 +71,7 @@ class BaseStrategy(ABC):
                 elif quantity < 0:
                     self.portfolio.sell_asset(symbol, abs(quantity))
                     self._record_trade(symbol, quantity, quantity)
-            except (ValueError, KeyError):
+            except ValueError:
                 self._record_trade(symbol, quantity, 0, success=False)
                 continue
 

--- a/tests/core/test_asset.py
+++ b/tests/core/test_asset.py
@@ -1,6 +1,3 @@
-from datetime import timedelta
-from math import isnan
-
 import pandas as pd
 from pytest import raises
 
@@ -87,54 +84,10 @@ def test_asset_index_strict_monotonicity():
 
 
 def test_asset_accessors(sample_asset):
-    end_time = sample_asset.end_time
-    start_time = sample_asset.start_time
     assert (sample_asset.price == sample_asset.data["price"]).all()
     assert sample_asset.income.equals(sample_asset.data["dividend"])
-
-    # get the values at a specific time.
-    assert sample_asset.get_price_at(end_time) == sample_asset.data["price"][end_time]
-
-    start_income = sample_asset.data["dividend"][start_time]
-    assert (
-        sample_asset.get_income_at(start_time) == 0.0
-        if isnan(start_income)
-        else start_income
-    )
-    end_income = sample_asset.data["dividend"][end_time]
-    assert (
-        sample_asset.get_income_at(end_time) == 0.0 if isnan(end_income) else end_income
-    )
-
-
-def test_asset_precise_price_access(sample_asset):
-    end_time = sample_asset.end_time
-    start_time = sample_asset.start_time
-
-    # retrieving values for a precise time outside the index raises an error
-    with raises(KeyError):
-        sample_asset.get_price_at(end_time + timedelta(days=1))
-
-    # retrieving values for an imprecise time before the start date raises an error
-    with raises(KeyError):
-        sample_asset.get_price_at(start_time - timedelta(days=1), precise=False)
-
-    # getting a value for an imprecise time (e.g. after the end date) does not raise
-    assert (
-        sample_asset.get_price_at(end_time + timedelta(days=1), precise=False)
-        == sample_asset.data["price"][end_time]
-    )
-
-
-def test_asset_income_precise_access(sample_asset):
-    end_time = sample_asset.end_time
-    start_time = sample_asset.start_time
-
-    # retrieving any value without a label returns 0
-    with raises(KeyError):
-        sample_asset.get_income_at(end_time + timedelta(days=1))
-    with raises(KeyError):
-        sample_asset.get_income_at(start_time - timedelta(days=1))
+    assert sample_asset.start_time == sample_asset.data.index[0]
+    assert sample_asset.end_time == sample_asset.data.index[-1]
 
 
 def test_asset_does_not_mutate_caller_dataframe(

--- a/tests/core/test_data_gaps.py
+++ b/tests/core/test_data_gaps.py
@@ -1,0 +1,267 @@
+"""Tests for data gaps handling.
+
+Two failure modes are tested, each with a distinct philosophy:
+
+1. Construction-time (fail-fast): Asset.__init__ rejects price data that contains NaN.
+   If a user provides a price series with NaN within its own declared date range, that
+   is data corruption and should be caught immediately.
+
+2. Trade-time (graceful failure): When a strategy attempts to trade an asset at a period
+   outside that asset's declared data range, the universe's price_matrix returns NaN
+   (due to reindex). buy_asset / sell_asset detect this and raise ValueError, which
+   execute_trades catches and records as success=False in trades_df.
+
+3. Income (silent zero): NaN income for a period means the asset has no data there.
+   collect_income treats it as zero — nothing to collect, no transaction registered.
+"""
+
+import pandas as pd
+import pytest
+
+from pyfolium.core import Asset, AssetUniverse, Portfolio
+from pyfolium.strategy import BaseStrategy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_universe_with_two_assets_different_start_dates():
+    """Return a universe where asset B starts one period after asset A.
+
+    Period index: [2023-01-01, 2023-01-02, 2023-01-03]
+    Asset A: data for all 3 periods.
+    Asset B: data only from 2023-01-02 onward.
+
+    The universe price_matrix therefore has NaN for B on 2023-01-01
+    (filled by reindex from the broader A range).
+    """
+    universe = AssetUniverse(data_frequency="D")
+    periods_a = pd.period_range("2023-01-01", periods=3, freq="D")
+    periods_b = pd.period_range("2023-01-02", periods=2, freq="D")
+
+    Asset(
+        symbol="A",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [10.0, 11.0, 12.0]}, index=periods_a),
+        price_column="price",
+    )
+    Asset(
+        symbol="B",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [20.0, 21.0]}, index=periods_b),
+        price_column="price",
+    )
+    return universe
+
+
+class _BuyBStrategy(BaseStrategy):
+    """Minimal strategy that always tries to buy 1 share of B."""
+
+    def get_trades(self) -> list[tuple[str, float]]:
+        return [("B", 1.0)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Construction-time NaN rejection
+# ---------------------------------------------------------------------------
+
+
+def test_asset_rejects_nan_prices():
+    """Asset.__init__ must raise ValueError when the price column contains NaN."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+    data_with_nan = pd.DataFrame({"price": [10.0, float("nan"), 12.0]}, index=periods)
+
+    with pytest.raises(ValueError, match="NaN"):
+        Asset(
+            symbol="GAP",
+            asset_universe=universe,
+            data=data_with_nan,
+            price_column="price",
+        )
+
+
+def test_asset_accepts_clean_prices():
+    """Asset.__init__ must succeed when the price column has no NaN."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+    data_clean = pd.DataFrame({"price": [10.0, 11.0, 12.0]}, index=periods)
+    asset = Asset(
+        symbol="CLEAN",
+        asset_universe=universe,
+        data=data_clean,
+        price_column="price",
+    )
+    assert asset.symbol == "CLEAN"
+
+
+def test_asset_accepts_nan_income_column():
+    """NaN in the income column must NOT be rejected — income NaN means zero income."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+    data = pd.DataFrame(
+        {"price": [10.0, 11.0, 12.0], "income": [0.5, float("nan"), 0.5]},
+        index=periods,
+    )
+    # Should not raise
+    asset = Asset(
+        symbol="INC",
+        asset_universe=universe,
+        data=data,
+        price_column="price",
+        income_column="income",
+    )
+    assert asset.symbol == "INC"
+
+
+# ---------------------------------------------------------------------------
+# 2. Trade-time graceful failure via execute_trades
+# ---------------------------------------------------------------------------
+
+
+def test_buy_before_asset_start_records_failure_in_trades_df():
+    """Buying an asset on a period before its data range records success=False.
+
+    The universe covers 2023-01-01 to 2023-01-03. Asset B only has data from
+    2023-01-02. On the first period (2023-01-01) the portfolio starts. A strategy
+    that tries to buy B on that period should see a failed trade recorded, and the
+    backtest should NOT crash.
+    """
+    universe = _make_universe_with_two_assets_different_start_dates()
+    portfolio = Portfolio(asset_universe=universe)
+
+    # Manually step the portfolio to the first period and execute the strategy
+    portfolio.collect_income()
+    portfolio.move_cash(10_000.0)
+
+    strategy = _BuyBStrategy(portfolio)
+    strategy.step()  # tries to buy B on 2023-01-01 (before B's data starts)
+
+    assert len(strategy.trades_df) == 1
+    trade = strategy.trades_df.iloc[0]
+    assert trade["symbol"] == "B"
+    assert trade["success"] == False  # noqa: E712 — numpy bool, not Python bool
+    assert trade["executed_quantity"] == 0
+
+    # Portfolio cash must be unchanged (trade was not executed)
+    assert portfolio.cash == 10_000.0
+    # Portfolio holdings must be zero for B
+    assert portfolio.holdings.loc[portfolio.current_period, "B"] == 0.0
+
+
+def test_buy_on_valid_period_succeeds():
+    """Buying asset B on a period within its data range records success=True."""
+    universe = _make_universe_with_two_assets_different_start_dates()
+    portfolio = Portfolio(asset_universe=universe)
+
+    # Advance to day 2 (2023-01-02) where B has price data
+    portfolio.collect_income()
+    portfolio.move_cash(10_000.0)
+    portfolio.update_history()
+    portfolio.advance_period()
+
+    portfolio.collect_income()
+    portfolio.move_cash(0.0)  # no-op
+
+    strategy = _BuyBStrategy(portfolio)
+    strategy.step()  # buys B on 2023-01-02 — price is 20.0
+
+    assert len(strategy.trades_df) == 1
+    trade = strategy.trades_df.iloc[0]
+    assert trade["symbol"] == "B"
+    assert trade["success"] == True  # noqa: E712 — numpy bool, not Python bool
+    assert trade["executed_quantity"] == 1.0
+    assert portfolio.holdings.loc[portfolio.current_period, "B"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 3. collect_income treats NaN income as zero
+# ---------------------------------------------------------------------------
+
+
+def test_collect_income_ignores_nan_income_outside_asset_range():
+    """collect_income must not create transactions for assets with NaN income.
+
+    Asset B starts on 2023-01-02, so its income column is NaN in the universe
+    income_matrix on 2023-01-01 (due to reindex). After buying A on day 1
+    and advancing to day 2, we verify that collect_income on day 1 produces
+    no income transaction for B (since B has no data on that day).
+    """
+    universe = AssetUniverse(data_frequency="D")
+    periods_a = pd.period_range("2023-01-01", periods=3, freq="D")
+    periods_b = pd.period_range("2023-01-02", periods=2, freq="D")
+
+    Asset(
+        symbol="A",
+        asset_universe=universe,
+        data=pd.DataFrame(
+            {"price": [10.0, 11.0, 12.0], "income": [1.0, 1.0, 1.0]},
+            index=periods_a,
+        ),
+        price_column="price",
+        income_column="income",
+    )
+    Asset(
+        symbol="B",
+        asset_universe=universe,
+        data=pd.DataFrame(
+            {"price": [20.0, 21.0], "income": [5.0, 5.0]},
+            index=periods_b,
+        ),
+        price_column="price",
+        income_column="income",
+    )
+
+    portfolio = Portfolio(asset_universe=universe)
+
+    # Day 1: deposit and buy A. B has NaN income on this day.
+    portfolio.collect_income()
+    portfolio.move_cash(10_000.0)
+    portfolio.buy_asset("A", 10.0)
+    portfolio.update_history()
+    portfolio.advance_period()
+
+    # Day 2: collect income. Only A should generate income (no phantom income from B
+    # that we happen not to hold).
+    portfolio.collect_income()
+
+    income_txns = portfolio.transactions[portfolio.transactions["type"] == "income"]
+    # A: 10 shares * 1.0 income = 10.0 → one income transaction expected
+    assert len(income_txns) == 1
+    assert income_txns.iloc[0]["symbol"] == "A"
+
+
+def test_collect_income_nan_income_for_held_asset_treated_as_zero():
+    """Holding an asset whose income is NaN on a given period produces no income txn.
+
+    We build a scenario where we hold B but collect_income runs on 2023-01-01
+    (before B's data starts). The income_matrix has NaN for B on that day.
+    collect_income must silently skip it — no transaction, no cash change.
+    """
+    universe = _make_universe_with_two_assets_different_start_dates()
+    portfolio = Portfolio(asset_universe=universe)
+
+    # Day 1: force a holding of B (simulate a carry-forward by directly setting)
+    # We can't use buy_asset since B has no price on day 1, so we manipulate holdings
+    # directly to simulate a scenario where we somehow hold B.
+    portfolio._states[portfolio.current_period] = __import__(
+        "pyfolium.core", fromlist=["PortfolioState"]
+    ).PortfolioState.TRANSACT
+    portfolio.holdings.loc[portfolio.current_period, "B"] = 5.0
+    portfolio._states[portfolio.current_period] = __import__(
+        "pyfolium.core", fromlist=["PortfolioState"]
+    ).PortfolioState.COLLECT_INCOME
+
+    # Now collect income. B has NaN income on 2023-01-01, A has no income column
+    # (no income column provided → income defaults to 0). Neither should generate
+    # an income transaction.
+    portfolio.collect_income()
+
+    income_txns = portfolio.transactions[portfolio.transactions["type"] == "income"]
+    assert len(income_txns) == 0
+    assert portfolio.cash == 0.0

--- a/tests/core/test_data_gaps.py
+++ b/tests/core/test_data_gaps.py
@@ -234,34 +234,3 @@ def test_collect_income_ignores_nan_income_outside_asset_range():
     # A: 10 shares * 1.0 income = 10.0 → one income transaction expected
     assert len(income_txns) == 1
     assert income_txns.iloc[0]["symbol"] == "A"
-
-
-def test_collect_income_nan_income_for_held_asset_treated_as_zero():
-    """Holding an asset whose income is NaN on a given period produces no income txn.
-
-    We build a scenario where we hold B but collect_income runs on 2023-01-01
-    (before B's data starts). The income_matrix has NaN for B on that day.
-    collect_income must silently skip it — no transaction, no cash change.
-    """
-    universe = _make_universe_with_two_assets_different_start_dates()
-    portfolio = Portfolio(asset_universe=universe)
-
-    # Day 1: force a holding of B (simulate a carry-forward by directly setting)
-    # We can't use buy_asset since B has no price on day 1, so we manipulate holdings
-    # directly to simulate a scenario where we somehow hold B.
-    portfolio._states[portfolio.current_period] = __import__(
-        "pyfolium.core", fromlist=["PortfolioState"]
-    ).PortfolioState.TRANSACT
-    portfolio.holdings.loc[portfolio.current_period, "B"] = 5.0
-    portfolio._states[portfolio.current_period] = __import__(
-        "pyfolium.core", fromlist=["PortfolioState"]
-    ).PortfolioState.COLLECT_INCOME
-
-    # Now collect income. B has NaN income on 2023-01-01, A has no income column
-    # (no income column provided → income defaults to 0). Neither should generate
-    # an income transaction.
-    portfolio.collect_income()
-
-    income_txns = portfolio.transactions[portfolio.transactions["type"] == "income"]
-    assert len(income_txns) == 0
-    assert portfolio.cash == 0.0


### PR DESCRIPTION
Layer 1 — construction-time (fail-fast):
  Asset.__init__ now rejects price series containing NaN. If a user
  provides a price column with NaN within the declared date range, that
  is data corruption and is caught at the source with a clear error.
  Income NaN is not rejected — it means "no income this period" and is
  handled gracefully downstream.

Layer 2 — trade-time (graceful failure):
  buy_asset/sell_asset detect NaN price (from universe reindex alignment
  when an asset has a narrower date range) and raise ValueError. This is
  caught by BaseStrategy.execute_trades, which records the trade with
  success=False in trades_df. Also adds KeyError to the except clause so
  that trades before an asset's start date (which raise KeyError in
  get_price_at) also fail gracefully rather than crashing the backtest.

Income handling:
  collect_income uses fillna(0) on income_this_period before the symbol
  filter and inside the loop, so assets with NaN income (outside their
  data range) produce no income transaction — silently treated as zero.

Additional fixes:
  - Resolved 22 pre-existing mypy errors caught by pre-commit's isolated
    environment but missed by `uv run mypy` (newer pandas-stubs version).
    Fixes: remove stale `# type: ignore`, add `[call-overload]` to
    _states period-keyed assignments, add `[operator]` to holdings
    loc += / -= augmented assignments.
  - CI now runs `pre-commit run --all-files` instead of separate ruff/mypy
    steps, so the CI environment matches the pre-commit environment exactly.
  - New test file tests/core/test_data_gaps.py with 7 focused tests.
  - Updated CLAUDE.md, DESIGN.md reference, and review-findings.md.

https://claude.ai/code/session_01C9nLLypHQpeSLDJWdJuR2m