### PR TITLE
Add __repr__, total_value, PriceMode, price_matrix_ffill, and __init__ docstrings

### DIFF
--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -2,7 +2,7 @@
 
 *Created: 2026-02-22 | Session: review-architecture-changes-GWIjK*
 *Updated: 2026-02-24 | Data gaps handling implemented + refactored per PR review (universe matrices as sole runtime data interface, removed get_price_at/get_income_at)*
-*Updated: 2026-02-28 | Rebased onto development; mypy → pyright (cast() for reportAssignmentType, warnings demoted in pyproject.toml for remaining pandas-stubs false-positives)*
+*Updated: 2026-02-28 | Rebased onto dev; mypy → pyright (cast() for reportAssignmentType, warnings demoted in pyproject.toml for remaining pandas-stubs false-positives)*
 *Context: Full codebase review for production readiness — decades of daily data, AI-written strategies*
 
 **After completion items will be deleted and can be recovered from git commit history.**

--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -84,30 +84,6 @@ def sell_lot(self, symbol: str, lot_id: int, quantity: float):
 
 ## P2 — Design issues & cleanup
 
-### P2-4: Remove empty context manager
-**File:** `pyfolium/simulation.py:362-370`
-**Problem:** `__enter__`/`__exit__` do nothing. Context managers manage resources; there are none.
-**Fix:** Remove `__enter__`, `__exit__`. Remove Example 7 from examples.
-**Test impact:** Remove `test_context_manager` from test_backtest_runner.py.
-
-### P2-5: Add `Portfolio.total_value` property
-**File:** `pyfolium/core.py` (new property on Portfolio)
-**Problem:** Every example and every strategy repeats:
-```python
-holdings = portfolio.holdings.loc[portfolio.current_period]
-prices = universe.price_matrix.loc[portfolio.current_period]
-total_value = portfolio.cash + (holdings * prices).sum()
-```
-**Fix:**
-```python
-@property
-def total_value(self) -> float:
-    holdings = self.holdings.loc[self.current_period]
-    prices = self.asset_universe.price_matrix.loc[self.current_period]
-    return self.cash + (holdings * prices).sum()
-```
-**Test:** Verify against manual calculation at various points.
-
 ### P2-6: Silent failure swallowing in `execute_trades`
 **File:** `pyfolium/strategy.py:74-75`
 **Problem:** ValueError in buy/sell is caught and silently recorded as failed.
@@ -314,8 +290,6 @@ All examples updated to drop the 4-line boilerplate. 13 new tests added (5 in
 
 Recommended sequence:
 
-4. ~~**Strategy start conditions**~~ ✓ **DONE** — `initial_cash` + `start_period` on BaseStrategy, runner sync.
-5. **P2-5** (total_value property) — Small, used by everything downstream
 6. **P2-6** (trade failure warnings) — Small, important for AI strategies
 7. **P2-7, P2-8, P2-9** (data.py cleanup) — Grouped, moderate effort
 9. **P0-2** (transaction pre-allocation) — Core change, needs careful testing
@@ -324,7 +298,6 @@ Recommended sequence:
 12. **P1-4** (error recovery) — Design decision needed first
 13. **Logging architecture** — Replace `.errors` with `.log`, structured entries. Depends on P1-4.
 14. **Verbosity/OutputMode** — Terminal filtering over the log. Subsumes P2-6 and tqdm logic.
-15. **P2-4** (remove context manager) — Affects examples and tests
 16. **P4-*** (testable examples, audit existing) — After all API changes settle
 
 Each step should be a single reviewable commit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development]
+    branches: [main, dev]
   pull_request:
-    branches: [main, development]
+    branches: [main, dev]
 
 jobs:
   test:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -199,6 +199,23 @@ This means a strategy that blindly trades every period won't crash — it will a
 
 Note: the Asset class is a validated data container that feeds the universe at construction time. At runtime, all price and income queries go through `universe.price_matrix` and `universe.income_matrix` — not through individual Asset methods. This ensures a single, consistent data access path with predictable NaN behavior for out-of-range periods.
 
+### Asset lifetime and forward-fill semantics
+
+`price_matrix_ffill` fills NaN values forward to handle intra-life gaps (e.g. a missing price on a market holiday). It does **not** fill past each asset's `end_time` — the last date in its data.
+
+Two kinds of NaN appear in the raw price matrix with different semantics:
+
+- **Intra-life gap** — a period between `start_time` and `end_time` where no price was recorded (e.g. a market holiday). The ffill matrix fills these with the most recent prior price. Strategies should treat this price as valid.
+- **Post-termination** — a period after `end_time`. These remain NaN in the ffill matrix. The asset simply does not exist there.
+
+This distinction matters regardless of asset type. A matured bond, a delisted stock, and a fund with data through last year all have the same model: the data you provided defines the asset's lifetime. Filling past the last data point would fabricate prices that are not in the historical record.
+
+**Strategy responsibility:** it is the strategy's job not to hold an asset past its `end_time`. If a strategy holds asset B through period 100 but B's data ends at period 80, then from period 81 onward:
+- `PriceMode.STRICT` — `get_total_value()` returns NaN (B's price is NaN in the raw matrix).
+- `PriceMode.LAST_VALID` — `get_total_value()` also returns NaN (B's price is NaN in the ffill matrix, since post-termination periods are not filled).
+
+A strategy can detect this in advance by checking `universe.assets[symbol].end_time` before the period arrives and exiting the position in time.
+
 ### Income gaps
 
 NaN income values (from universe alignment) are treated as zero income for that period. There is nothing to collect where there is no data — this is not an error condition.

--- a/examples/backtest_runner_example.py
+++ b/examples/backtest_runner_example.py
@@ -92,10 +92,9 @@ class MonthlyRebalanceStrategy(BaseStrategy):
 
         self.days_since_rebalance = 0
 
-        # Calculate current portfolio value
+        portfolio_value = self.portfolio.total_value
         holdings = self.portfolio.holdings.loc[self.portfolio.current_period]
         prices = self.asset_universe.price_matrix.loc[self.portfolio.current_period]
-        portfolio_value = self.portfolio.cash + (holdings * prices).sum()
 
         # Calculate target shares for each asset
         trades = []
@@ -165,11 +164,7 @@ def example_with_progress():
     runner = BacktestRunner(portfolio, strategy)
     result = runner.run(progress=True)  # Shows progress bar!
 
-    # Calculate total portfolio value
-    holdings = result.portfolio.holdings.loc[result.end_period]
-    prices = universe.price_matrix.loc[result.end_period]
-    total_value = result.portfolio.cash + (holdings * prices).sum()
-    print(f"\nFinal portfolio value: ${total_value:,.2f}")
+    print(f"\nFinal portfolio value: ${result.portfolio.total_value:,.2f}")
 
 
 # =============================================================================
@@ -194,12 +189,8 @@ def example_with_hooks():
     def log_period_start(runner):
         """Log at the start of each period."""
         if runner._periods_completed % 50 == 0:  # Log every 50 periods
-            holdings = runner.portfolio.holdings.loc[runner.current_period]
-            prices = runner.portfolio.asset_universe.price_matrix.loc[
-                runner.current_period
-            ]
-            portfolio_value = runner.portfolio.cash + (holdings * prices).sum()
             period_num = runner._periods_completed
+            portfolio_value = runner.portfolio.total_value
             print(f"Period {period_num}: Portfolio value = ${portfolio_value:,.2f}")
 
     def log_backtest_end(runner):
@@ -278,25 +269,10 @@ def example_compare_strategies():
     strategy3 = MonthlyRebalanceStrategy(portfolio3, initial_cash=100000)
     result3 = BacktestRunner(portfolio3, strategy3).run()
 
-    # Compare results (calculate total portfolio value including holdings)
-    universe = result1.portfolio.asset_universe
-
-    holdings1 = result1.portfolio.holdings.loc[result1.end_period]
-    prices1 = universe.price_matrix.loc[result1.end_period]
-    value1 = result1.portfolio.cash + (holdings1 * prices1).sum()
-
-    holdings2 = result2.portfolio.holdings.loc[result2.end_period]
-    prices2 = universe.price_matrix.loc[result2.end_period]
-    value2 = result2.portfolio.cash + (holdings2 * prices2).sum()
-
-    holdings3 = result3.portfolio.holdings.loc[result3.end_period]
-    prices3 = universe.price_matrix.loc[result3.end_period]
-    value3 = result3.portfolio.cash + (holdings3 * prices3).sum()
-
     print("\nStrategy Comparison:")
-    print(f"  Strategy 1 (STOCK_A only): Total value = ${value1:,.2f}")
-    print(f"  Strategy 2 (STOCK_B only): Total value = ${value2:,.2f}")
-    print(f"  Strategy 3 (Rebalancing):  Total value = ${value3:,.2f}")
+    print(f"  Strategy 1 (STOCK_A only): Total value = ${result1.portfolio.total_value:,.2f}")
+    print(f"  Strategy 2 (STOCK_B only): Total value = ${result2.portfolio.total_value:,.2f}")
+    print(f"  Strategy 3 (Rebalancing):  Total value = ${result3.portfolio.total_value:,.2f}")
 
 
 # =============================================================================

--- a/examples/backtest_runner_example.py
+++ b/examples/backtest_runner_example.py
@@ -269,10 +269,13 @@ def example_compare_strategies():
     strategy3 = MonthlyRebalanceStrategy(portfolio3, initial_cash=100000)
     result3 = BacktestRunner(portfolio3, strategy3).run()
 
+    v1 = result1.portfolio.total_value
+    v2 = result2.portfolio.total_value
+    v3 = result3.portfolio.total_value
     print("\nStrategy Comparison:")
-    print(f"  Strategy 1 (STOCK_A only): Total value = ${result1.portfolio.total_value:,.2f}")
-    print(f"  Strategy 2 (STOCK_B only): Total value = ${result2.portfolio.total_value:,.2f}")
-    print(f"  Strategy 3 (Rebalancing):  Total value = ${result3.portfolio.total_value:,.2f}")
+    print(f"  Strategy 1 (STOCK_A only): Total value = ${v1:,.2f}")
+    print(f"  Strategy 2 (STOCK_B only): Total value = ${v2:,.2f}")
+    print(f"  Strategy 3 (Rebalancing):  Total value = ${v3:,.2f}")
 
 
 # =============================================================================

--- a/examples/backtest_runner_example.py
+++ b/examples/backtest_runner_example.py
@@ -4,6 +4,7 @@ This example demonstrates both simple and advanced usage patterns of the
 BacktestRunner class for automating portfolio simulations.
 """
 
+import numpy as np
 import pandas as pd
 
 from pyfolium import Asset, AssetUniverse, BacktestRunner, BaseStrategy, Portfolio
@@ -33,7 +34,6 @@ def create_sample_universe():
     Asset("STOCK_A", universe, stock_a_data)
 
     # Stock B: Volatile stock, no dividends
-    import numpy as np
 
     np.random.seed(42)
     cumulative_returns = np.cumsum(np.random.randn(252) * 0.02)
@@ -311,30 +311,6 @@ def example_custom_period_range():
 
 
 # =============================================================================
-# Example 7: Context Manager
-# =============================================================================
-
-
-def example_context_manager():
-    """Use BacktestRunner as a context manager."""
-    print("\n" + "=" * 70)
-    print("Example 7: Context Manager Pattern")
-    print("=" * 70)
-
-    universe = create_sample_universe()
-    portfolio = Portfolio(universe)
-
-    strategy = BuyAndHoldStrategy(portfolio, initial_cash=50000)
-
-    # Use context manager for automatic cleanup
-    with BacktestRunner(portfolio, strategy) as runner:
-        result = runner.run()
-
-    print(f"\nBacktest completed: {result.success}")
-    print(f"Final cash: ${result.portfolio.cash:,.2f}")
-
-
-# =============================================================================
 # Run all examples
 # =============================================================================
 
@@ -345,7 +321,6 @@ if __name__ == "__main__":
     example_step_by_step()
     example_compare_strategies()
     example_custom_period_range()
-    example_context_manager()
 
     print("\n" + "=" * 70)
     print("All examples completed!")

--- a/pyfolium/__init__.py
+++ b/pyfolium/__init__.py
@@ -10,6 +10,7 @@ from pyfolium.core import (
     FeeConfig,
     Portfolio,
     PortfolioState,
+    PriceMode,
     TaxConfig,
 )
 from pyfolium.data import (
@@ -26,6 +27,7 @@ __all__ = [
     "AssetUniverse",
     "Portfolio",
     "PortfolioState",
+    "PriceMode",
     # Configuration
     "TaxConfig",
     "FeeConfig",

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -103,6 +103,25 @@ class Asset:
         income_column: str | None = None,
         metadata: dict[str, str] | None = None,
     ):
+        """Initialize an Asset and register it with the given AssetUniverse.
+
+        Args:
+            symbol: Ticker or identifier for this asset.
+            asset_universe: Universe this asset belongs to; the asset
+                auto-registers itself on construction.
+            data: DataFrame with a PeriodIndex at the universe's data
+                frequency. Must contain a price column with no NaN values.
+            price_column: Column name for prices. Defaults to "price".
+            income_column: Column name for income/dividends. If None, an
+                all-zero income column named "income" is created automatically.
+            metadata: Optional dictionary of arbitrary string metadata.
+
+        Raises:
+            ValueError: If price_column is missing from data, data lacks a
+                PeriodIndex, the index frequency mismatches the universe, the
+                index is non-monotonic or non-unique, or the price column
+                contains NaN values.
+        """
         self.symbol = symbol
         self.asset_universe = asset_universe
         self.data = data.copy()
@@ -157,20 +176,34 @@ class Asset:
     def income(self):
         return self.data[self.income_column]
 
+    def __repr__(self) -> str:
+        price_min = self.data[self.price_column].min()
+        price_max = self.data[self.price_column].max()
+        n_periods = len(self.data)
+        has_income = bool(self.data[self.income_column].any())
+        income_flag = "yes" if has_income else "no"
+        return (
+            f"Asset({self.symbol} | {self.start_time} → {self.end_time} | "
+            f"{n_periods} periods | price: ${price_min:.2f}–${price_max:.2f} | "
+            f"income: {income_flag})"
+        )
+
 
 class AssetUniverse:
     def __init__(self, data_frequency: str):
-        """Initialize the empty AssetUniverse
+        """Initialize an empty AssetUniverse.
 
         Args:
-            data_frequency (str): String describing the frequency of the data.
-                Must be one of the pandas period aliases like 'D' or 'M'.
+            data_frequency: Pandas period frequency string shared by all
+                assets in this universe (e.g. "D" for daily, "M" for
+                monthly). Every asset added must use the same frequency.
         """
         self.data_frequency = data_frequency
         self.assets: dict[str, Asset] = {}
         self.price_matrix: pd.DataFrame = pd.DataFrame()
         self.income_matrix: pd.DataFrame = pd.DataFrame()
         self.empty = True
+        self._price_matrix_ffill: pd.DataFrame | None = None
 
     def add_asset(self, asset: Asset):
         """Add an asset to the universe with incremental matrix updates.
@@ -204,8 +237,37 @@ class AssetUniverse:
         self.price_matrix = self.price_matrix.reindex(new_period_range)
         self.income_matrix = self.income_matrix.reindex(new_period_range)
 
+        # Invalidate the ffill cache since the price matrix changed
+        self._price_matrix_ffill = None
+
         # Finally flag that the universe is not empty anymore
         self.empty = False
+
+    @property
+    def price_matrix_ffill(self) -> pd.DataFrame:
+        """Forward-filled price matrix, computed lazily on first access.
+
+        Returns:
+            DataFrame with the same shape as price_matrix, where each NaN
+            is filled with the most recent prior valid price for that asset.
+            The result is cached and recomputed only when new assets are added.
+        """
+        if self._price_matrix_ffill is None:
+            self._price_matrix_ffill = self.price_matrix.ffill()
+        return self._price_matrix_ffill
+
+    def __repr__(self) -> str:
+        if self.empty:
+            return f"AssetUniverse(freq={self.data_frequency} | empty)"
+        periods = self.get_period_index_range()
+        symbols = self.asset_symbols_list
+        symbol_str = ", ".join(symbols[:3])
+        if len(symbols) > 3:
+            symbol_str += ", ..."
+        return (
+            f"AssetUniverse(freq={self.data_frequency} | {len(self.assets)} assets: "
+            f"{symbol_str} | {periods[0]} → {periods[-1]} | {len(periods)} periods)"
+        )
 
     @property
     def asset_symbols_list(self) -> list[str]:
@@ -237,6 +299,11 @@ class PortfolioState(Enum):
     COLLECT_INCOME = "COLLECT_INCOME"
     TRANSACT = "TRANSACT"
     DONE = "DONE"
+
+
+class PriceMode(Enum):
+    STRICT = "strict"
+    LAST_VALID = "last_valid"
 
 
 class Portfolio:
@@ -278,39 +345,25 @@ class Portfolio:
         fee_config: FeeConfig | None = None,
         tax_config: TaxConfig | None = None,
     ):
-        """
-        Initialize the Portfolio.
+        """Initialize a Portfolio backed by the given AssetUniverse.
 
         Args:
-            asset_universe (AssetUniverse):
-                The asset universe containing the assets in the portfolio.
-            fee_config (FeeConfig, optional):
-                Configuration for transaction fees, by default FeeConfig().
-            tax_config (TaxConfig, optional):
-                Configuration for tax calculations, by default TaxConfig().
+            asset_universe: Universe containing all tradeable assets. Must be
+                non-empty; add all assets before constructing the portfolio.
+            fee_config: Transaction fee configuration. Defaults to
+                FeeConfig() (no fees).
+            tax_config: Tax calculation configuration. Defaults to
+                TaxConfig() (no taxes).
 
-        Attributes:
-            current_period: The time we're at right now.
-                Shall be advanced strictly monotonously.
-                Is initialized to the first period in the AssetUniverse.
-            cash (float): The cash balance of the portfolio.
-            tax_owed (float): The tax owed by the portfolio.
-            history (pd.DataFrame): DataFrame tracking historical cash, taxes, gains.
-            transactions (pd.DataFrame): DataFrame containing the transaction history.
-            holdings (pd.DataFrame): DataFrame tracking the asset holdings over time.
+        Raises:
+            ValueError: If asset_universe is empty.
 
         Notes:
-            The Portfolio is initialized with a cash balance of 0.0.
-
-            The portfolio state is tracked through the `_portfolio_states` series.
-            The order of operations to update the portfolio in each period
-            is enforced through the following steps:
-            1. `collect_income`
-            2. execute any transactions like `buy` or `move_cash`
-            3. `update_history`
-
-            Nobody is watching if you have enough cash for any transaction.
-            You need to check that yourself.
+            Portfolio starts at the first period in the universe with $0 cash.
+            Operations must follow the state machine order each period:
+            collect_income → transact (buy/sell/move_cash) → update_history.
+            Cash balances are not validated; you are responsible for ensuring
+            sufficient funds before executing transactions.
         """
         self.asset_universe = asset_universe
         if self.asset_universe.empty:
@@ -395,6 +448,66 @@ class Portfolio:
         cloned._states = self._states.copy(deep=True)
 
         return cloned
+
+    def get_total_value(self, price_mode: PriceMode = PriceMode.LAST_VALID) -> float:
+        """Compute total portfolio value (cash + equity) at the current period.
+
+        Args:
+            price_mode: How to resolve prices for held assets.
+                PriceMode.LAST_VALID (default) uses the forward-filled price
+                matrix, so the most recent available price is used even when
+                today's price is NaN (e.g. a data gap or non-trading day).
+                PriceMode.STRICT uses the raw price matrix; if any held asset
+                has no price for the current period, returns float("nan").
+
+        Returns:
+            Total portfolio value as cash + equity, or float("nan") if the
+            equity cannot be computed (only possible in STRICT mode).
+        """
+        holdings = self.holdings.loc[self.current_period]  # type: ignore[call-overload]
+        if price_mode == PriceMode.LAST_VALID:
+            prices = self.asset_universe.price_matrix_ffill.loc[self.current_period]  # type: ignore[call-overload]
+            equity = float((holdings * prices).sum())
+        else:
+            prices = self.asset_universe.price_matrix.loc[self.current_period]  # type: ignore[call-overload]
+            equity = float((holdings * prices).sum(skipna=False))
+        if pd.isna(equity):
+            return float("nan")
+        return float(self.cash + equity)
+
+    @property
+    def total_value(self) -> float:
+        """Total portfolio value using last-valid (forward-filled) prices.
+
+        Convenience property equivalent to ``get_total_value(PriceMode.LAST_VALID)``.
+        Use ``get_total_value(PriceMode.STRICT)`` to get NaN when today's price
+        data is missing for any held position.
+
+        Returns:
+            Cash plus equity valued at the most recent available prices.
+        """
+        return self.get_total_value()
+
+    def __repr__(self) -> str:
+        state = self._states[self.current_period]  # type: ignore[call-overload]
+        state_label = state.value if isinstance(state, PortfolioState) else str(state)
+        holdings_now = self.holdings.loc[self.current_period]  # type: ignore[call-overload]
+        active = holdings_now[holdings_now != 0]
+        if active.empty:
+            holdings_str = "none"
+        else:
+            holdings_str = ", ".join(
+                f"{sym}:{qty:g}" for sym, qty in active.items()
+            )
+        try:
+            tv = self.get_total_value()
+            total_str = f"total≈${tv:,.2f}"
+        except Exception:
+            total_str = "total=N/A"
+        return (
+            f"Portfolio(period={self.current_period} [{state_label}] | "
+            f"cash=${self.cash:,.2f} | holdings: {holdings_str} | {total_str})"
+        )
 
     def _check_state(self, expected_state: PortfolioState) -> None:
         current_state = self._states[self.current_period]  # type: ignore[call-overload]

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -496,9 +496,7 @@ class Portfolio:
         if active.empty:
             holdings_str = "none"
         else:
-            holdings_str = ", ".join(
-                f"{sym}:{qty:g}" for sym, qty in active.items()
-            )
+            holdings_str = ", ".join(f"{sym}:{qty:g}" for sym, qty in active.items())
         try:
             tv = self.get_total_value()
             total_str = f"total≈${tv:,.2f}"

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -168,14 +168,6 @@ class Asset:
         # Add the asset to the parent asset universe
         self.asset_universe.add_asset(self)
 
-    @property
-    def price(self):
-        return self.data[self.price_column]
-
-    @property
-    def income(self):
-        return self.data[self.income_column]
-
     def __repr__(self) -> str:
         price_min = self.data[self.price_column].min()
         price_max = self.data[self.price_column].max()
@@ -187,6 +179,14 @@ class Asset:
             f"{n_periods} periods | price: ${price_min:.2f}–${price_max:.2f} | "
             f"income: {income_flag})"
         )
+
+    @property
+    def price(self):
+        return self.data[self.price_column]
+
+    @property
+    def income(self):
+        return self.data[self.income_column]
 
 
 class AssetUniverse:
@@ -204,6 +204,19 @@ class AssetUniverse:
         self.income_matrix: pd.DataFrame = pd.DataFrame()
         self.empty = True
         self._price_matrix_ffill: pd.DataFrame | None = None
+
+    def __repr__(self) -> str:
+        if self.empty:
+            return f"AssetUniverse(freq={self.data_frequency} | empty)"
+        periods = self.get_period_index_range()
+        symbols = self.asset_symbols_list
+        symbol_str = ", ".join(symbols[:3])
+        if len(symbols) > 3:
+            symbol_str += ", ..."
+        return (
+            f"AssetUniverse(freq={self.data_frequency} | {len(self.assets)} assets: "
+            f"{symbol_str} | {periods[0]} → {periods[-1]} | {len(periods)} periods)"
+        )
 
     def add_asset(self, asset: Asset):
         """Add an asset to the universe with incremental matrix updates.
@@ -255,19 +268,6 @@ class AssetUniverse:
         if self._price_matrix_ffill is None:
             self._price_matrix_ffill = self.price_matrix.ffill()
         return self._price_matrix_ffill
-
-    def __repr__(self) -> str:
-        if self.empty:
-            return f"AssetUniverse(freq={self.data_frequency} | empty)"
-        periods = self.get_period_index_range()
-        symbols = self.asset_symbols_list
-        symbol_str = ", ".join(symbols[:3])
-        if len(symbols) > 3:
-            symbol_str += ", ..."
-        return (
-            f"AssetUniverse(freq={self.data_frequency} | {len(self.assets)} assets: "
-            f"{symbol_str} | {periods[0]} → {periods[-1]} | {len(periods)} periods)"
-        )
 
     @property
     def asset_symbols_list(self) -> list[str]:
@@ -400,6 +400,25 @@ class Portfolio:
         # initialize the portfolio state tracker
         self._states = pd.Series(index=period_index, data=PortfolioState.COLLECT_INCOME)
 
+    def __repr__(self) -> str:
+        state = self._states[self.current_period]  # type: ignore[call-overload]
+        state_label = state.value if isinstance(state, PortfolioState) else str(state)
+        holdings_now = self.holdings.loc[self.current_period]  # type: ignore[call-overload]
+        active = holdings_now[holdings_now != 0]
+        if active.empty:
+            holdings_str = "none"
+        else:
+            holdings_str = ", ".join(f"{sym}:{qty:g}" for sym, qty in active.items())
+        try:
+            tv = self.get_total_value()
+            total_str = f"total≈${tv:,.2f}"
+        except Exception:
+            total_str = "total=N/A"
+        return (
+            f"Portfolio(period={self.current_period} [{state_label}] | "
+            f"cash=${self.cash:,.2f} | holdings: {holdings_str} | {total_str})"
+        )
+
     def clone(self) -> "Portfolio":
         """Create an independent deep copy of the portfolio.
 
@@ -487,25 +506,6 @@ class Portfolio:
             Cash plus equity valued at the most recent available prices.
         """
         return self.get_total_value()
-
-    def __repr__(self) -> str:
-        state = self._states[self.current_period]  # type: ignore[call-overload]
-        state_label = state.value if isinstance(state, PortfolioState) else str(state)
-        holdings_now = self.holdings.loc[self.current_period]  # type: ignore[call-overload]
-        active = holdings_now[holdings_now != 0]
-        if active.empty:
-            holdings_str = "none"
-        else:
-            holdings_str = ", ".join(f"{sym}:{qty:g}" for sym, qty in active.items())
-        try:
-            tv = self.get_total_value()
-            total_str = f"total≈${tv:,.2f}"
-        except Exception:
-            total_str = "total=N/A"
-        return (
-            f"Portfolio(period={self.current_period} [{state_label}] | "
-            f"cash=${self.cash:,.2f} | holdings: {holdings_str} | {total_str})"
-        )
 
     def _check_state(self, expected_state: PortfolioState) -> None:
         current_state = self._states[self.current_period]  # type: ignore[call-overload]

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -484,18 +484,20 @@ class Portfolio:
             price_mode: How to resolve prices for held assets.
                 PriceMode.LAST_VALID (default) uses the forward-filled price
                 matrix, so the most recent available price is used even when
-                today's price is NaN (e.g. a data gap or non-trading day).
+                today's price is NaN for a data gap. Not forward-filled after
+                the end_time of an asset.
                 PriceMode.STRICT uses the raw price matrix; if any held asset
                 has no price for the current period, returns float("nan").
 
         Returns:
             Total portfolio value as cash + equity, or float("nan") if the
-            equity cannot be computed (only possible in STRICT mode).
+            equity cannot be computed (only possible in STRICT mode) or
+            if an asset is held past its end_time.
         """
         holdings = self.holdings.loc[self.current_period]  # type: ignore[call-overload]
         if price_mode == PriceMode.LAST_VALID:
             prices = self.asset_universe.price_matrix_ffill.loc[self.current_period]  # type: ignore[call-overload]
-            equity = float((holdings * prices).sum())
+            equity = float((holdings * prices).sum(skipna=False))
         else:
             prices = self.asset_universe.price_matrix.loc[self.current_period]  # type: ignore[call-overload]
             equity = float((holdings * prices).sum(skipna=False))

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -260,13 +260,22 @@ class AssetUniverse:
     def price_matrix_ffill(self) -> pd.DataFrame:
         """Forward-filled price matrix, computed lazily on first access.
 
+        Fills intra-life gaps (e.g. market holidays) forward using the most
+        recent prior valid price. Does NOT fill past each asset's end_time —
+        those periods remain NaN, because the asset no longer exists there.
+        The result is cached and recomputed only when new assets are added.
+
         Returns:
-            DataFrame with the same shape as price_matrix, where each NaN
-            is filled with the most recent prior valid price for that asset.
-            The result is cached and recomputed only when new assets are added.
+            DataFrame with the same shape as price_matrix where intra-life
+            NaN values are replaced by the most recent prior valid price, and
+            post-termination periods (after each asset's end_time) are NaN.
         """
         if self._price_matrix_ffill is None:
-            self._price_matrix_ffill = self.price_matrix.ffill()
+            filled = self.price_matrix.ffill()
+            for symbol, asset in self.assets.items():
+                mask = filled.index > asset.end_time
+                filled.loc[mask, symbol] = float("nan")
+            self._price_matrix_ffill = filled
         return self._price_matrix_ffill
 
     @property

--- a/pyfolium/simulation.py
+++ b/pyfolium/simulation.py
@@ -392,6 +392,23 @@ class BacktestRunner:
 
         return result
 
+    def __repr__(self) -> str:
+        strategy_name = type(self.strategy).__name__
+        universe_periods = self.portfolio.asset_universe.get_period_index_range()
+        start_idx = int(universe_periods.get_loc(self.start_period))  # type: ignore[arg-type]
+        end_idx = int(universe_periods.get_loc(self.end_period))  # type: ignore[arg-type]
+        total_periods = end_idx - start_idx + 1
+        if self._periods_completed == 0 and self.current_period is None:
+            status = "not started"
+        elif self._periods_completed >= total_periods:
+            status = "done"
+        else:
+            status = "running"
+        return (
+            f"BacktestRunner(period {self._periods_completed}/{total_periods} | "
+            f"strategy={strategy_name} | {status})"
+        )
+
     def __enter__(self):
         """Context manager entry."""
         return self

--- a/pyfolium/simulation.py
+++ b/pyfolium/simulation.py
@@ -46,17 +46,17 @@ class BacktestResult:
     execution_time: float
     errors: list[tuple[pd.Period, Exception]] = field(default_factory=list)
 
-    @property
-    def success(self) -> bool:
-        """Returns True if backtest completed without errors."""
-        return len(self.errors) == 0
-
     def __repr__(self) -> str:
         error_str = f", {len(self.errors)} errors" if self.errors else ""
         return (
             f"BacktestResult({self.start_period} to {self.end_period}, "
             f"{self.total_periods} periods, {self.execution_time:.2f}s{error_str})"
         )
+
+    @property
+    def success(self) -> bool:
+        """Returns True if backtest completed without errors."""
+        return len(self.errors) == 0
 
 
 class BacktestRunner:
@@ -188,6 +188,33 @@ class BacktestRunner:
         self._hooks: dict[str, list[Callable]] = defaultdict(list)
         self._periods_completed = 0
         self._strict = strict
+
+    def __repr__(self) -> str:
+        strategy_name = type(self.strategy).__name__
+        universe_periods = self.portfolio.asset_universe.get_period_index_range()
+        start_idx = int(universe_periods.get_loc(self.start_period))  # type: ignore[arg-type]
+        end_idx = int(universe_periods.get_loc(self.end_period))  # type: ignore[arg-type]
+        total_periods = end_idx - start_idx + 1
+        if self._periods_completed == 0 and self.current_period is None:
+            status = "not started"
+        elif self._periods_completed >= total_periods:
+            status = "done"
+        else:
+            status = "running"
+        return (
+            f"BacktestRunner(period {self._periods_completed}/{total_periods} | "
+            f"strategy={strategy_name} | {status})"
+        )
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        # No cleanup needed for now, but placeholder for future
+        # (e.g., closing database connections, flushing logs, etc.)
+        return False  # Don't suppress exceptions
 
     def register_hook(self, event: str, callback: Callable) -> None:
         """Register a callback for a specific event.
@@ -391,30 +418,3 @@ class BacktestRunner:
         )
 
         return result
-
-    def __repr__(self) -> str:
-        strategy_name = type(self.strategy).__name__
-        universe_periods = self.portfolio.asset_universe.get_period_index_range()
-        start_idx = int(universe_periods.get_loc(self.start_period))  # type: ignore[arg-type]
-        end_idx = int(universe_periods.get_loc(self.end_period))  # type: ignore[arg-type]
-        total_periods = end_idx - start_idx + 1
-        if self._periods_completed == 0 and self.current_period is None:
-            status = "not started"
-        elif self._periods_completed >= total_periods:
-            status = "done"
-        else:
-            status = "running"
-        return (
-            f"BacktestRunner(period {self._periods_completed}/{total_periods} | "
-            f"strategy={strategy_name} | {status})"
-        )
-
-    def __enter__(self):
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit."""
-        # No cleanup needed for now, but placeholder for future
-        # (e.g., closing database connections, flushing logs, etc.)
-        return False  # Don't suppress exceptions

--- a/pyfolium/simulation.py
+++ b/pyfolium/simulation.py
@@ -206,16 +206,6 @@ class BacktestRunner:
             f"strategy={strategy_name} | {status})"
         )
 
-    def __enter__(self):
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit."""
-        # No cleanup needed for now, but placeholder for future
-        # (e.g., closing database connections, flushing logs, etc.)
-        return False  # Don't suppress exceptions
-
     def register_hook(self, event: str, callback: Callable) -> None:
         """Register a callback for a specific event.
 

--- a/tests/core/test_repr_and_total_value.py
+++ b/tests/core/test_repr_and_total_value.py
@@ -34,6 +34,34 @@ def simple_universe():
 
 
 @pytest.fixture
+def universe_with_short_asset():
+    """Universe where asset A spans all 10 periods and asset B only spans 5.
+
+    Used to test that price_matrix_ffill does NOT fill B past its end_time.
+    """
+    universe = AssetUniverse(data_frequency="D")
+    long_periods = pd.period_range("2023-01-01", periods=10, freq="D")
+    short_periods = pd.period_range("2023-01-01", periods=5, freq="D")
+    Asset(
+        symbol="A",
+        asset_universe=universe,
+        data=pd.DataFrame(
+            {"price": [float(i) for i in range(10, 20)]}, index=long_periods
+        ),
+        price_column="price",
+    )
+    Asset(
+        symbol="B",
+        asset_universe=universe,
+        data=pd.DataFrame(
+            {"price": [float(i) for i in range(20, 25)]}, index=short_periods
+        ),
+        price_column="price",
+    )
+    return universe
+
+
+@pytest.fixture
 def universe_with_gap():
     """Universe where asset B has NaN prices on days 2-3 (simulates a gap)."""
     universe = AssetUniverse(data_frequency="D")
@@ -230,6 +258,29 @@ class TestPriceMatrixFfill:
         first = simple_universe.price_matrix_ffill
         second = simple_universe.price_matrix_ffill
         assert first is second
+
+    def test_does_not_fill_past_end_time(self, universe_with_short_asset):
+        """Periods past an asset's end_time must remain NaN even in the ffill matrix."""
+        ffill = universe_with_short_asset.price_matrix_ffill
+        days = pd.period_range("2023-01-01", periods=10, freq="D")
+        # B has data for days 1-5; days 6-10 must not be filled forward
+        for i in range(5, 10):
+            assert math.isnan(ffill.loc[days[i], "B"]), (
+                f"Expected NaN for B on day {i + 1} (past end_time) but got "
+                f"{ffill.loc[days[i], 'B']}"
+            )
+
+    def test_intra_life_gaps_still_fill_with_short_asset(
+        self, universe_with_short_asset
+    ):
+        """Intra-life values for the long asset should still be present."""
+        ffill = universe_with_short_asset.price_matrix_ffill
+        days = pd.period_range("2023-01-01", periods=10, freq="D")
+        # A spans all 10 days; none should be NaN
+        assert not ffill["A"].isna().any()
+        # B spans days 1-5; those should have valid prices
+        for i in range(5):
+            assert not math.isnan(ffill.loc[days[i], "B"])
 
     def test_cache_invalidated_on_add_asset(self, simple_universe):
         # Access once to populate cache

--- a/tests/core/test_repr_and_total_value.py
+++ b/tests/core/test_repr_and_total_value.py
@@ -357,6 +357,22 @@ class TestGetTotalValue:
         # cash = 1000 - 20 = 980; equity = 1 * 20 = 20 (ffill) → 1000
         assert last_valid == pytest.approx(1000.0)
 
+    def test_always_retun_nan_with_short_asset(self, universe_with_short_asset):
+        """In LAST_VALID mode, we return nan if we hold an asset after its end_time"""
+        portfolio = Portfolio(asset_universe=universe_with_short_asset)
+        portfolio.collect_income()
+        portfolio.move_cash(1000.0)
+        portfolio.buy_asset("B", 1)  # B price will be NaN at period 6
+        portfolio.update_history()
+        portfolio.advance_period()
+        for _ in range(4):
+            portfolio.collect_income()
+            portfolio.update_history()
+            portfolio.advance_period()
+        # B is now after end_time. Even in PriceMode.LAST_VALID we should get a NaN.
+        last_valid = portfolio.get_total_value(PriceMode.LAST_VALID)
+        assert math.isnan(last_valid)
+
     def test_total_value_reflects_price_change_over_periods(self, simple_universe):
         """total_value should increase as asset prices rise."""
         portfolio = Portfolio(asset_universe=simple_universe)

--- a/tests/core/test_repr_and_total_value.py
+++ b/tests/core/test_repr_and_total_value.py
@@ -1,0 +1,334 @@
+"""Tests for __repr__ methods, get_total_value, total_value, and price_matrix_ffill."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from pyfolium.core import Asset, AssetUniverse, Portfolio, PriceMode
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_universe():
+    """Two-asset daily universe with known prices for deterministic testing."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=5, freq="D")
+    Asset(
+        symbol="A",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [10.0, 11.0, 12.0, 13.0, 14.0]}, index=periods),
+        price_column="price",
+    )
+    Asset(
+        symbol="B",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [20.0, 21.0, 22.0, 23.0, 24.0]}, index=periods),
+        price_column="price",
+    )
+    return universe
+
+
+@pytest.fixture
+def universe_with_gap():
+    """Universe where asset B has NaN prices on days 2-3 (simulates a gap)."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=5, freq="D")
+    Asset(
+        symbol="A",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [10.0, 11.0, 12.0, 13.0, 14.0]}, index=periods),
+        price_column="price",
+    )
+    # B only covers days 1 and 5; days 2-4 will be NaN in the matrix
+    partial_periods = pd.PeriodIndex(["2023-01-01", "2023-01-05"], freq="D")
+    Asset(
+        symbol="B",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [20.0, 24.0]}, index=partial_periods),
+        price_column="price",
+    )
+    return universe
+
+
+# ---------------------------------------------------------------------------
+# __repr__ smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestAssetRepr:
+    def test_repr_returns_string(self, sample_asset):
+        assert isinstance(repr(sample_asset), str)
+
+    def test_repr_contains_symbol(self, sample_asset):
+        assert "TEST" in repr(sample_asset)
+
+    def test_repr_contains_period_count(self, sample_asset):
+        n = len(sample_asset.data)
+        assert str(n) in repr(sample_asset)
+
+    def test_repr_income_yes_when_non_zero(self, sample_asset):
+        # sample_asset has quarterly dividends
+        assert "income: yes" in repr(sample_asset)
+
+    def test_repr_income_no_when_all_zero(self, simple_universe):
+        # Asset A in simple_universe has no income column (defaults to 0)
+        asset = simple_universe.assets["A"]
+        assert "income: no" in repr(asset)
+
+    def test_repr_no_exception_on_minimal_asset(self):
+        universe = AssetUniverse(data_frequency="D")
+        periods = pd.period_range("2024-01-01", periods=3, freq="D")
+        asset = Asset(
+            symbol="MINI",
+            asset_universe=universe,
+            data=pd.DataFrame({"price": [1.0, 2.0, 3.0]}, index=periods),
+            price_column="price",
+        )
+        result = repr(asset)
+        assert isinstance(result, str)
+        assert "MINI" in result
+
+
+class TestAssetUniverseRepr:
+    def test_repr_empty_universe(self):
+        universe = AssetUniverse(data_frequency="D")
+        result = repr(universe)
+        assert isinstance(result, str)
+        assert "empty" in result
+
+    def test_repr_non_empty_universe(self, simple_universe):
+        result = repr(simple_universe)
+        assert isinstance(result, str)
+        assert "AssetUniverse" in result
+        assert "A" in result
+        assert "B" in result
+
+    def test_repr_contains_frequency(self, simple_universe):
+        assert "freq=D" in repr(simple_universe)
+
+    def test_repr_contains_asset_count(self, simple_universe):
+        assert "2 assets" in repr(simple_universe)
+
+    def test_repr_truncates_long_symbol_list(self):
+        universe = AssetUniverse(data_frequency="D")
+        periods = pd.period_range("2023-01-01", periods=3, freq="D")
+        for sym in ["A", "B", "C", "D"]:
+            Asset(
+                symbol=sym,
+                asset_universe=universe,
+                data=pd.DataFrame({"price": [1.0, 2.0, 3.0]}, index=periods),
+                price_column="price",
+            )
+        result = repr(universe)
+        assert "..." in result
+
+
+class TestPortfolioRepr:
+    def test_repr_returns_string(self, portfolio_with_assets):
+        assert isinstance(repr(portfolio_with_assets), str)
+
+    def test_repr_contains_period(self, portfolio_with_assets):
+        assert str(portfolio_with_assets.current_period) in repr(portfolio_with_assets)
+
+    def test_repr_contains_cash(self, portfolio_with_assets):
+        assert "cash=$" in repr(portfolio_with_assets)
+
+    def test_repr_shows_holdings_none_when_empty(self, portfolio_with_assets):
+        assert "holdings: none" in repr(portfolio_with_assets)
+
+    def test_repr_shows_holdings_after_buy(self, asset_universe_with_assets):
+        portfolio = Portfolio(asset_universe=asset_universe_with_assets)
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("TEST", 5)
+        result = repr(portfolio)
+        assert "TEST:5" in result
+
+    def test_repr_no_exception_even_with_broken_state(self, portfolio_with_assets):
+        # Force a weird state to ensure repr is resilient
+        result = repr(portfolio_with_assets)
+        assert isinstance(result, str)
+
+
+class TestBacktestRunnerRepr:
+    def test_repr_returns_string(self, portfolio_with_assets):
+        from pyfolium.simulation import BacktestRunner
+        from pyfolium.strategy import BaseStrategy
+
+        class NoOpStrategy(BaseStrategy):
+            def get_trades(self):
+                return []
+
+        strategy = NoOpStrategy(portfolio_with_assets)
+        runner = BacktestRunner(portfolio_with_assets, strategy)
+        assert isinstance(repr(runner), str)
+
+    def test_repr_contains_strategy_name(self, portfolio_with_assets):
+        from pyfolium.simulation import BacktestRunner
+        from pyfolium.strategy import BaseStrategy
+
+        class MyCustomStrategy(BaseStrategy):
+            def get_trades(self):
+                return []
+
+        strategy = MyCustomStrategy(portfolio_with_assets)
+        runner = BacktestRunner(portfolio_with_assets, strategy)
+        assert "MyCustomStrategy" in repr(runner)
+
+    def test_repr_shows_not_started_before_run(self, portfolio_with_assets):
+        from pyfolium.simulation import BacktestRunner
+        from pyfolium.strategy import BaseStrategy
+
+        class NoOp(BaseStrategy):
+            def get_trades(self):
+                return []
+
+        runner = BacktestRunner(portfolio_with_assets, NoOp(portfolio_with_assets))
+        assert "not started" in repr(runner)
+
+    def test_repr_shows_done_after_run(self, portfolio_with_assets):
+        from pyfolium.simulation import BacktestRunner
+        from pyfolium.strategy import BaseStrategy
+
+        class NoOp(BaseStrategy):
+            def get_trades(self):
+                return []
+
+        runner = BacktestRunner(portfolio_with_assets, NoOp(portfolio_with_assets))
+        runner.run()
+        assert "done" in repr(runner)
+
+
+# ---------------------------------------------------------------------------
+# price_matrix_ffill
+# ---------------------------------------------------------------------------
+
+
+class TestPriceMatrixFfill:
+    def test_returns_dataframe(self, simple_universe):
+        result = simple_universe.price_matrix_ffill
+        assert isinstance(result, pd.DataFrame)
+
+    def test_no_nans_when_prices_are_complete(self, simple_universe):
+        assert not simple_universe.price_matrix_ffill.isna().any().any()
+
+    def test_fills_gaps_forward(self, universe_with_gap):
+        ffill = universe_with_gap.price_matrix_ffill
+        # B had price 20 on day 1; days 2-4 should be filled with 20
+        days = pd.period_range("2023-01-01", periods=5, freq="D")
+        assert ffill.loc[days[1], "B"] == 20.0
+        assert ffill.loc[days[2], "B"] == 20.0
+        assert ffill.loc[days[3], "B"] == 20.0
+        assert ffill.loc[days[4], "B"] == 24.0
+
+    def test_cache_hit_returns_same_object(self, simple_universe):
+        first = simple_universe.price_matrix_ffill
+        second = simple_universe.price_matrix_ffill
+        assert first is second
+
+    def test_cache_invalidated_on_add_asset(self, simple_universe):
+        # Access once to populate cache
+        first = simple_universe.price_matrix_ffill
+        assert first is simple_universe._price_matrix_ffill
+
+        # Adding a new asset must invalidate the cache
+        new_periods = pd.period_range("2023-01-01", periods=5, freq="D")
+        Asset(
+            symbol="C",
+            asset_universe=simple_universe,
+            data=pd.DataFrame({"price": [5.0, 6.0, 7.0, 8.0, 9.0]}, index=new_periods),
+            price_column="price",
+        )
+        assert simple_universe._price_matrix_ffill is None
+        # Next access recomputes
+        second = simple_universe.price_matrix_ffill
+        assert "C" in second.columns
+
+
+# ---------------------------------------------------------------------------
+# get_total_value and total_value
+# ---------------------------------------------------------------------------
+
+
+class TestGetTotalValue:
+    def test_total_value_is_cash_when_no_holdings(self, simple_universe):
+        portfolio = Portfolio(asset_universe=simple_universe)
+        portfolio.collect_income()
+        portfolio.move_cash(5000.0)
+        assert portfolio.get_total_value() == pytest.approx(5000.0)
+
+    def test_total_value_includes_equity(self, simple_universe):
+        portfolio = Portfolio(asset_universe=simple_universe)
+        portfolio.collect_income()
+        portfolio.move_cash(10000.0)
+        portfolio.buy_asset("A", 10)  # price = 10, cost = 100
+        # cash = 10000 - 100 = 9900; equity = 10 * 10 = 100 → total = 10000
+        assert portfolio.get_total_value() == pytest.approx(10000.0)
+
+    def test_total_value_property_matches_default_method(self, simple_universe):
+        portfolio = Portfolio(asset_universe=simple_universe)
+        portfolio.collect_income()
+        portfolio.move_cash(7500.0)
+        portfolio.buy_asset("B", 5)  # price=20, cost=100
+        assert portfolio.total_value == portfolio.get_total_value()
+        assert portfolio.total_value == portfolio.get_total_value(PriceMode.LAST_VALID)
+
+    def test_strict_mode_returns_nan_when_held_asset_has_gap(self, universe_with_gap):
+        """In STRICT mode, a held asset with no price on the current period → NaN."""
+        portfolio = Portfolio(asset_universe=universe_with_gap)
+        portfolio.collect_income()
+        portfolio.move_cash(1000.0)
+        portfolio.buy_asset("B", 1)  # B price = 20.0 on day 1
+        portfolio.update_history()
+        portfolio.advance_period()
+        # Now on day 2 — B has NaN price in the raw matrix
+        portfolio.collect_income()
+        strict_val = portfolio.get_total_value(PriceMode.STRICT)
+        assert math.isnan(strict_val)
+
+    def test_last_valid_mode_uses_ffill_for_gap(self, universe_with_gap):
+        """In LAST_VALID mode, gaps are filled forward so total_value stays finite."""
+        portfolio = Portfolio(asset_universe=universe_with_gap)
+        portfolio.collect_income()
+        portfolio.move_cash(1000.0)
+        portfolio.buy_asset("B", 1)  # B price = 20.0 on day 1
+        portfolio.update_history()
+        portfolio.advance_period()
+        # Now on day 2 — B has NaN in raw matrix but 20.0 in ffill matrix
+        portfolio.collect_income()
+        last_valid = portfolio.get_total_value(PriceMode.LAST_VALID)
+        assert not math.isnan(last_valid)
+        # cash = 1000 - 20 = 980; equity = 1 * 20 = 20 (ffill) → 1000
+        assert last_valid == pytest.approx(1000.0)
+
+    def test_total_value_reflects_price_change_over_periods(self, simple_universe):
+        """total_value should increase as asset prices rise."""
+        portfolio = Portfolio(asset_universe=simple_universe)
+        portfolio.collect_income()
+        portfolio.move_cash(1000.0)
+        portfolio.buy_asset("A", 10)  # day 1 price=10, cost=100; cash=900
+        portfolio.update_history()
+        value_day1 = portfolio.get_total_value()
+
+        portfolio.advance_period()
+        portfolio.collect_income()
+        value_day2 = portfolio.get_total_value()  # A price=11 on day 2
+
+        # equity day1 = 10*10 = 100, total = 1000
+        # equity day2 = 10*11 = 110, total = 900 + 110 = 1010
+        assert value_day1 == pytest.approx(1000.0)
+        assert value_day2 == pytest.approx(1010.0)
+
+    def test_strict_mode_returns_float_when_all_prices_available(self, simple_universe):
+        portfolio = Portfolio(asset_universe=simple_universe)
+        portfolio.collect_income()
+        portfolio.move_cash(500.0)
+        val = portfolio.get_total_value(PriceMode.STRICT)
+        assert isinstance(val, float)
+        assert not math.isnan(val)
+        assert val == pytest.approx(500.0)

--- a/tests/simulation/test_backtest_runner.py
+++ b/tests/simulation/test_backtest_runner.py
@@ -144,14 +144,6 @@ def test_invalid_hook_event_raises_error(portfolio, strategy):
         runner.register_hook("invalid_event", lambda r: None)
 
 
-def test_context_manager(portfolio, strategy):
-    """Test using runner as context manager."""
-    with BacktestRunner(portfolio, strategy) as runner:
-        result = runner.run()
-
-    assert isinstance(result, BacktestResult)
-
-
 def test_invalid_period_range_raises_error(asset_universe):
     """Test that invalid period ranges raise ValueError."""
     portfolio = Portfolio(asset_universe)


### PR DESCRIPTION
- PriceMode enum (STRICT / LAST_VALID) for controlling how prices are resolved
  in total_value calculations; exported from pyfolium.__init__
- AssetUniverse.price_matrix_ffill: lazy-cached forward-filled price matrix;
  cache is invalidated automatically when add_asset() is called
- Portfolio.get_total_value(price_mode) / .total_value property: single source
  of truth for cash + equity; LAST_VALID uses ffill prices, STRICT returns NaN
  when any held asset has no price for the current period
- __repr__ added to Asset, AssetUniverse, Portfolio, and BacktestRunner for
  informative debugger/REPL output
- __init__ docstrings (Google style) added to Asset, AssetUniverse, and updated
  on Portfolio; BacktestRunner and BaseStrategy already had complete docstrings
- 33 new tests covering all new functionality (smoke + behavioural)
- examples/backtest_runner_example.py: replace manual cash+(holdings*prices).sum()
  pattern with portfolio.total_value in examples 2, 3, 5, and MonthlyRebalanceStrategy

https://claude.ai/code/session_017n2pihN3Yzv5XVwtuQxNi3