### PR TITLE
Add sell_lot() for specific tax lot targeting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ This state machine is enforced via `PortfolioState` enum to prevent operations i
 - Runtime price/income queries go through `universe.price_matrix`/`income_matrix`, not Asset methods
 
 **TaxLot** (`pyfolium/core.py`): Dataclass representing a single purchase lot
-- Created by `buy_asset()`, consumed by `sell_asset()` in FIFO/LIFO order
-- Tracks `symbol`, `period`, `quantity`, `quantity_remaining`, `cost_basis_per_share`
+- Created by `buy_asset()`, consumed by `sell_asset()` (FIFO/LIFO) or `sell_lot()` (specific lot)
+- Tracks `symbol`, `period`, `quantity`, `quantity_remaining`, `cost_basis_per_share`, `txn_index`
 - Exposed to strategies via `portfolio.open_lots` for lot-level introspection
 
 **Portfolio** (`pyfolium/core.py`): The core backtesting engine
@@ -101,6 +101,7 @@ This state machine is enforced via `PortfolioState` enum to prevent operations i
 - Tax lots tracked as `TaxLot` dataclass instances via `_tax_lots: dict[str, list[TaxLot]]`
 - Period index `_txn_period_index: dict[Period, list[int]]` for O(1) per-period transaction lookup
 - Current period tracked via `current_period` / `_current_period_idx`; hot paths use `.iloc` for performance
+- `sell_lot(lot, quantity)` sells from a specific TaxLot, bypassing FIFO/LIFO; shares `_execute_lot_sales()` with `sell_asset()`
 - `clone()` method creates independent copy for strategy comparison
 
 **BaseStrategy** (`pyfolium/strategy.py`): Abstract class for trading strategies
@@ -203,5 +204,6 @@ Recent features:
 - **Pydantic validation**: TaxConfig and FeeConfig with automatic validation
 - **Data loading**: `load_from_csv` and `load_from_dataframe` utilities with explicit `income_column` (defaults to `None`; raises `ValueError` when an explicitly named column is missing) and `min_density` sanity check (default `0.5`) that catches frequency mismatches like monthly data loaded as daily
 - **Comprehensive examples**: 7 usage patterns in examples/backtest_runner_example.py; benchmark in examples/benchmark.py
+- **sell_lot() (P1-5)**: `sell_lot(lot, quantity)` sells from a specific `TaxLot` obtained via `portfolio.open_lots`, bypassing FIFO/LIFO ordering; enables tax-loss harvesting and tax-optimized strategies; shares `_execute_lot_sales()` helper with `sell_asset()`
 
 See `.claude/review-findings.md` for the full architecture review and action plan.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,7 +73,7 @@ The Portfolio is the central object. It tracks:
 - **Holdings** — a DataFrame of position quantities indexed by period and asset symbol.
 - **Transactions** — a complete log of every buy, sell, and cash movement. Stored internally as a list-of-dicts buffer; exposed as a DataFrame via `portfolio.transactions`.
 - **History** — a per-period snapshot of the portfolio state (cash, holdings value, tax owed).
-- **Tax lots** — `TaxLot` dataclass instances tracking per-share cost basis for capital gains. Exposed via `portfolio.open_lots`.
+- **Tax lots** — `TaxLot` dataclass instances tracking per-share cost basis for capital gains. Exposed via `portfolio.open_lots`. Sold either via FIFO/LIFO order (`sell_asset()`) or by specific lot reference (`sell_lot()`).
 
 ### Why a single cash balance?
 
@@ -160,12 +160,18 @@ This is tracked in the review findings under the implementation roadmap.
 
 ### Tax lot tracking
 
-Each purchase creates a `TaxLot` dataclass — a first-class record of the lot's symbol, purchase period, original quantity, remaining quantity, and per-share cost basis. When selling, lots are consumed in FIFO or LIFO order. This enables:
+Each purchase creates a `TaxLot` dataclass — a first-class record of the lot's symbol, purchase period, original quantity, remaining quantity, and per-share cost basis. Lots can be consumed in two ways:
+
+1. **Default FIFO/LIFO order** via `sell_asset()`, which respects `TaxConfig.tax_strategy`
+2. **Specific lot targeting** via `sell_lot(lot, quantity)`, which accepts a `TaxLot` from `portfolio.open_lots` and sells from it directly, bypassing FIFO/LIFO ordering
+
+Both methods share `_execute_lot_sales()` for tax/fee/gain calculation. This enables:
 
 - Accurate capital gains calculation for any holding period
 - Short-term vs long-term gain classification
-- Strategy-level lot inspection via `portfolio.open_lots` (e.g. for tax-loss harvesting)
-- Future: specific lot identification via `sell_lot()` and custom lot selection via `TaxConfig.select_lots()`
+- Strategy-level lot inspection via `portfolio.open_lots`
+- Tax-loss harvesting via `sell_lot()` (select specific lots with losses)
+- Future: custom lot selection via `TaxConfig.select_lots()`
 
 ### Transaction buffer
 

--- a/README.md
+++ b/README.md
@@ -242,11 +242,12 @@ COLLECT_INCOME → TRANSACT → DONE → advance_period() → COLLECT_INCOME
 
 ### Tax Lot Tracking
 - `TaxLot` dataclass: first-class lot records with symbol, period, quantity, cost basis
-- FIFO or LIFO accounting for capital gains
+- FIFO or LIFO accounting for capital gains via `sell_asset()`
+- Specific lot targeting via `sell_lot(lot, quantity)` for tax-loss harvesting
 - Per-share cost basis tracking
 - Automatic short/long-term classification
 - Optional immediate tax withholding
-- `portfolio.open_lots` exposes open lots to strategies (e.g. tax-loss harvesting)
+- `portfolio.open_lots` exposes open lots to strategies
 
 ## Examples
 

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -904,7 +904,79 @@ class Portfolio:
                 f"Quantity to sell {quantity} is greater than current holdings "
                 f"{current_holding_quantity} for symbol {symbol}."
             )
-        quantity_to_sell = quantity
+
+        # Build lot-quantity pairs in FIFO/LIFO order
+        lots_to_sell: list[tuple[TaxLot, float]] = []
+        remaining = quantity
+        for lot in open_lots:
+            take = min(remaining, lot.quantity_remaining)
+            lots_to_sell.append((lot, take))
+            remaining -= take
+            if remaining <= 0:
+                break
+
+        self._execute_lot_sales(symbol, lots_to_sell, quantity)
+
+    def sell_lot(self, lot: TaxLot, quantity: float) -> None:
+        """Sell shares from a specific tax lot.
+
+        Unlike ``sell_asset()`` which consumes lots in FIFO/LIFO order,
+        this method targets a single lot chosen by the caller. This enables
+        tax-loss harvesting and other tax-optimized strategies.
+
+        Args:
+            lot: The TaxLot to sell from. Must be an open lot belonging
+                to this portfolio (obtained via ``open_lots``).
+            quantity: Number of shares to sell. Must be positive and
+                at most ``lot.quantity_remaining``.
+
+        Raises:
+            RuntimeError: If portfolio is not in TRANSACT state.
+            ValueError: If quantity is invalid, lot is closed, or lot
+                does not belong to this portfolio.
+        """
+        self._check_state(PortfolioState.TRANSACT)
+
+        if quantity <= 0:
+            raise ValueError("Quantity must be greater than 0")
+
+        if not lot.is_open:
+            raise ValueError(
+                f"Lot for {lot.symbol} (period={lot.period}) is closed; "
+                "no shares remain to sell."
+            )
+
+        owned_lots = self._tax_lots.get(lot.symbol, [])
+        if not any(lot is existing for existing in owned_lots):
+            raise ValueError(
+                "Lot does not belong to this portfolio. "
+                "Use portfolio.open_lots to obtain lot references."
+            )
+
+        if quantity > lot.quantity_remaining:
+            raise ValueError(
+                f"Quantity {quantity} exceeds lot's remaining shares "
+                f"{lot.quantity_remaining}."
+            )
+
+        self._execute_lot_sales(lot.symbol, [(lot, quantity)], quantity)
+
+    def _execute_lot_sales(
+        self,
+        symbol: str,
+        lots_to_sell: list[tuple[TaxLot, float]],
+        total_quantity: float,
+    ) -> None:
+        """Shared implementation for sell_asset and sell_lot.
+
+        Handles price lookup, fee calculation, gain classification,
+        tax withholding, transaction registration, and portfolio updates.
+
+        Args:
+            symbol: Asset symbol being sold.
+            lots_to_sell: Pairs of (lot, quantity_from_this_lot).
+            total_quantity: Total shares being sold across all lots.
+        """
         col_idx = self.holdings.columns.get_loc(symbol)
         raw_price = self.asset_universe.price_matrix.iloc[
             self._current_period_idx, col_idx  # type: ignore[call-overload]
@@ -915,8 +987,8 @@ class Portfolio:
                 "no price data for this period"
             )
         price = float(raw_price)  # type: ignore[arg-type]
-        fee = self.fee_config.calculate_fee(quantity * price)
-        cost_basis_per_share = price - fee / quantity
+        fee = self.fee_config.calculate_fee(total_quantity * price)
+        sell_basis_per_share = price - fee / total_quantity
 
         long_term_gains = 0.0
         short_term_gains = 0.0
@@ -926,10 +998,9 @@ class Portfolio:
             - self.tax_config.long_term_holding_period
         ).to_period(self.asset_universe.data_frequency)
 
-        for lot in open_lots:
-            lot_quantity_sold = min(quantity_to_sell, lot.quantity_remaining)
+        for lot, lot_quantity_sold in lots_to_sell:
             lot_gains = lot_quantity_sold * (
-                cost_basis_per_share - lot.cost_basis_per_share
+                sell_basis_per_share - lot.cost_basis_per_share
             )
 
             if lot.period <= earliest_long_term_period:
@@ -938,17 +1009,10 @@ class Portfolio:
                 short_term_gains += lot_gains
 
             lot.quantity_remaining -= lot_quantity_sold
-            # SYNC: TaxLot.quantity_remaining is the authoritative source;
-            # the buffer entry must mirror it so .transactions reflects
-            # partial sales. If the buffer schema changes, update this too.
             self._txn_buffer[lot.txn_index]["lot_quantity_remaining"] = (
                 lot.quantity_remaining
             )
             self._txn_df_cache = None
-
-            quantity_to_sell -= lot_quantity_sold
-            if quantity_to_sell <= 0:
-                break
 
         tax_liability = (
             long_term_gains * self.tax_config.long_term_rate
@@ -961,12 +1025,12 @@ class Portfolio:
             tax_paid = tax_liability
             tax_liability = 0.0
 
-        transaction_amount = quantity * price - fee - tax_paid
+        transaction_amount = total_quantity * price - fee - tax_paid
 
         self._register_transaction(
             type="sell",
             symbol=symbol,
-            quantity=quantity,
+            quantity=total_quantity,
             price=price,
             fee=fee,
             tax_paid=tax_paid,
@@ -975,7 +1039,7 @@ class Portfolio:
             transaction_amount=transaction_amount,
         )
 
-        self.holdings.iloc[self._current_period_idx, col_idx] -= quantity  # type: ignore[operator]
+        self.holdings.iloc[self._current_period_idx, col_idx] -= total_quantity  # type: ignore[operator]
 
         self.cash += transaction_amount
         self.tax_owed += tax_liability

--- a/tests/core/test_tax_lot.py
+++ b/tests/core/test_tax_lot.py
@@ -459,3 +459,214 @@ class TestCollectIncomeWithTaxLots:
 
         # The lot should still be intact
         assert p._tax_lots["A"][0].quantity_remaining == 10.0
+
+
+# ---------------------------------------------------------------------------
+# sell_lot — specific lot identification
+# ---------------------------------------------------------------------------
+
+
+class TestSellLot:
+    """Tests for Portfolio.sell_lot() which sells from a specific TaxLot."""
+
+    def test_sell_lot_basic(self, portfolio):
+        """Partial sell from a specific lot updates quantity and holdings."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 3)
+
+        assert lot.quantity_remaining == approx(7.0)
+        assert portfolio.holdings.iloc[0]["A"] == approx(7.0)
+
+    def test_sell_lot_full(self, portfolio):
+        """Selling entire lot closes it and zeros out holdings."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 10)
+
+        assert lot.quantity_remaining == 0.0
+        assert lot.is_open is False
+        assert portfolio.holdings.iloc[0]["A"] == approx(0.0)
+
+    def test_sell_lot_cash_updated(self, portfolio):
+        """Cash increases by (quantity * price - fee) after selling a lot."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+        cash_before = portfolio.cash
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 5)
+
+        # price=100, no fees/taxes by default
+        assert portfolio.cash == approx(cash_before + 5 * 100.0)
+
+    def test_sell_lot_quantity_exceeds_remaining(self, portfolio):
+        """Selling more than lot.quantity_remaining raises ValueError."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        with pytest.raises(ValueError, match="exceeds"):
+            portfolio.sell_lot(lot, 15)
+
+    def test_sell_lot_zero_quantity(self, portfolio):
+        """Selling zero raises ValueError."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        with pytest.raises(ValueError, match="greater than 0"):
+            portfolio.sell_lot(lot, 0)
+
+    def test_sell_lot_negative_quantity(self, portfolio):
+        """Selling negative raises ValueError."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        with pytest.raises(ValueError, match="greater than 0"):
+            portfolio.sell_lot(lot, -5)
+
+    def test_sell_lot_closed_lot(self, portfolio):
+        """Selling from an already-closed lot raises ValueError."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 10)  # close it
+
+        with pytest.raises(ValueError, match="closed"):
+            portfolio.sell_lot(lot, 1)
+
+    def test_sell_lot_wrong_portfolio(self, universe):
+        """Selling a lot that doesn't belong to this portfolio raises ValueError."""
+        p1 = Portfolio(universe)
+        p2 = Portfolio(universe)
+
+        p1.collect_income()
+        p1.move_cash(10000)
+        p1.buy_asset("A", 10)
+
+        p2.collect_income()
+        p2.move_cash(10000)
+
+        lot_from_p1 = p1._tax_lots["A"][0]
+        with pytest.raises(ValueError, match="does not belong"):
+            p2.sell_lot(lot_from_p1, 5)
+
+    def test_sell_lot_wrong_state(self, portfolio):
+        """sell_lot outside TRANSACT state raises RuntimeError."""
+        # Portfolio starts in COLLECT_INCOME state
+        with pytest.raises(RuntimeError):
+            lot = TaxLot("A", pd.Period("2020-01-01", freq="D"), 10, 10, 100.0, 0)
+            portfolio.sell_lot(lot, 5)
+
+    def test_sell_lot_transaction_registered(self, portfolio):
+        """A sell transaction is recorded in portfolio.transactions."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 5)
+
+        sells = portfolio.transactions[portfolio.transactions["type"] == "sell"]
+        assert len(sells) == 1
+        assert sells.iloc[0]["symbol"] == "A"
+        assert sells.iloc[0]["quantity"] == approx(5.0)
+        assert sells.iloc[0]["price"] == approx(100.0)
+
+    def test_sell_lot_with_fees(self, portfolio_with_fees):
+        """Fee is applied to the sell_lot transaction."""
+        p = portfolio_with_fees
+        p.collect_income()
+        p.move_cash(100000)
+        p.buy_asset("A", 10)
+
+        lot = p._tax_lots["A"][0]
+        p.sell_lot(lot, 5)
+
+        sells = p.transactions[p.transactions["type"] == "sell"]
+        # fee = 1.0 + 0.01 * (5 * 100) = 1.0 + 5.0 = 6.0
+        assert sells.iloc[0]["fee"] == approx(6.0)
+
+    def test_sell_lot_short_term_gains(self, portfolio_with_taxes):
+        """Selling in same period classifies gains as short-term."""
+        p = portfolio_with_taxes
+        p.collect_income()
+        p.move_cash(10000)
+        p.buy_asset("A", 10)
+        p.update_history()
+
+        # Advance to a period where price might differ — but our fixture
+        # uses constant price=100, so gains = 0. We still verify classification.
+        p.advance_period()
+        p.collect_income()
+
+        lot = p._tax_lots["A"][0]
+        p.sell_lot(lot, 5)
+
+        sells = p.transactions[p.transactions["type"] == "sell"]
+        # With constant price and no fees, gains are 0
+        assert sells.iloc[0]["short_term_gains"] == approx(0.0)
+        assert sells.iloc[0]["long_term_gains"] == approx(0.0)
+
+    def test_sell_lot_buffer_synced(self, portfolio):
+        """Buffer lot_quantity_remaining matches after sell_lot."""
+        portfolio.collect_income()
+        portfolio.move_cash(10000)
+        portfolio.buy_asset("A", 10)
+        buy_idx = portfolio._tax_lots["A"][0].txn_index
+
+        lot = portfolio._tax_lots["A"][0]
+        portfolio.sell_lot(lot, 3)
+
+        assert portfolio._txn_buffer[buy_idx]["lot_quantity_remaining"] == approx(7.0)
+
+    def test_sell_lot_bypasses_fifo_lifo(self, portfolio):
+        """sell_lot targets a specific lot, ignoring FIFO/LIFO ordering."""
+        portfolio.collect_income()
+        portfolio.move_cash(50000)
+        portfolio.buy_asset("A", 10)  # lot 0
+        portfolio.update_history()
+
+        portfolio.advance_period()
+        portfolio.collect_income()
+        portfolio.buy_asset("A", 10)  # lot 1
+
+        # Sell from lot 1 (second lot) — FIFO would sell lot 0 first
+        lot_1 = portfolio._tax_lots["A"][1]
+        portfolio.sell_lot(lot_1, 5)
+
+        # lot 0 is untouched, lot 1 partially consumed
+        assert portfolio._tax_lots["A"][0].quantity_remaining == approx(10.0)
+        assert portfolio._tax_lots["A"][1].quantity_remaining == approx(5.0)
+
+    def test_sell_lot_via_open_lots(self, portfolio):
+        """Strategies access lots through open_lots and pass to sell_lot."""
+        portfolio.collect_income()
+        portfolio.move_cash(50000)
+        portfolio.buy_asset("A", 10)
+        portfolio.update_history()
+
+        portfolio.advance_period()
+        portfolio.collect_income()
+        portfolio.buy_asset("A", 10)
+
+        # Strategy pattern: pick a lot from open_lots
+        open_lots = portfolio.open_lots["A"]
+        assert len(open_lots) == 2
+        portfolio.sell_lot(open_lots[1], 5)
+
+        assert open_lots[1].quantity_remaining == approx(5.0)


### PR DESCRIPTION
## Summary
Implement `Portfolio.sell_lot()` to enable selling from a specific tax lot, bypassing FIFO/LIFO ordering. This supports tax-loss harvesting and other tax-optimized strategies while maintaining consistent fee, tax, and gain calculation logic.

## Key Changes

- **New `sell_lot(lot, quantity)` method**: Accepts a `TaxLot` reference from `portfolio.open_lots` and sells a specified quantity from that lot only, with full validation (lot ownership, open status, quantity bounds).

- **Refactored `sell_asset()` and `_execute_lot_sales()`**: Extracted common fee/tax/gain logic into a shared `_execute_lot_sales()` helper that both `sell_asset()` (FIFO/LIFO) and `sell_lot()` (specific lot) use. This ensures consistent treatment of:
  - Fee calculation and per-share basis adjustment
  - Short-term vs long-term gain classification
  - Tax withholding and liability tracking
  - Transaction registration and buffer synchronization

- **Comprehensive test coverage**: 14 new tests covering:
  - Basic partial and full lot sales
  - Cash and holdings updates
  - Validation (exceeds quantity, zero/negative, closed lot, wrong portfolio, wrong state)
  - Fee and tax application
  - Buffer synchronization
  - FIFO/LIFO bypass behavior
  - Strategy integration via `open_lots`

- **Documentation updates**: DESIGN.md and CLAUDE.md clarified to reflect dual consumption paths (FIFO/LIFO vs specific lot targeting).

## Implementation Details

- `sell_lot()` validates that the lot belongs to the portfolio and is open before proceeding
- Both methods build a `list[tuple[TaxLot, float]]` of (lot, quantity_from_lot) pairs passed to `_execute_lot_sales()`
- Gain classification and tax withholding logic remains unchanged; only the lot selection mechanism differs
- `TaxLot.txn_index` field enables buffer synchronization for partial sales

https://claude.ai/code/session_01SWx2A3weLvNEvgd99kyi3U