### PR TITLE
Add trade context to FeeConfig.calculate_fee for extensibility

### DIFF
--- a/.claude/review-findings.md
+++ b/.claude/review-findings.md
@@ -101,7 +101,7 @@ Users should be able to subclass or replace them for their jurisdiction.
    - `select_lots(lots, strategy) → ordered_lots` (subsumes FIFO/LIFO + specific lot ID)
 2. **Phase 2:** Portfolio calls config methods instead of implementing tax math directly.
    Default TaxConfig keeps today's behavior. Subclasses override for wash sales, etc.
-3. **Phase 3:** Same pattern for FeeConfig if needed (tiered commissions, etc.)
+3. ~~**Phase 3:** Same pattern for FeeConfig if needed (tiered commissions, etc.)~~ ✓ DONE
 
 **Depends on:** P0-3 (tax lot data structure) for the lot selection interface.
 **Design doc:** See `DESIGN.md` "Configs as templates" section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Fee calculation (`FeeConfig` in `pyfolium/core.py`) uses Pydantic for validation
 - Percentage-based fee (validated 0.0-1.0)
 - Minimum and maximum fee caps (validated max >= min)
 - Fees incorporated into cost basis for tax calculations
-- `calculate_fee(transaction_value, *, symbol, quantity, transaction_type)` is overridable; Portfolio passes trade context so subclasses can implement tiered commissions, per-asset fees, or buy/sell-asymmetric pricing
+- `calculate_fee(transaction_value, *, symbol, quantity, transaction_type, metadata)` is overridable; Portfolio passes trade context (including the asset's `metadata` dict) so subclasses can implement tiered commissions, per-asset-class fees, or buy/sell-asymmetric pricing
 
 ## Testing Patterns
 
@@ -217,7 +217,7 @@ Recent features:
 - **Data loading**: `load_from_csv` and `load_from_dataframe` utilities with explicit `income_column` (defaults to `None`; raises `ValueError` when an explicitly named column is missing) and `min_density` sanity check (default `0.5`) that catches frequency mismatches like monthly data loaded as daily
 - **Comprehensive examples**: 7 usage patterns in examples/backtest_runner_example.py; benchmark in examples/benchmark.py
 - **sell_lot() (P1-5)**: `sell_lot(lot, quantity)` sells from a specific `TaxLot` obtained via `portfolio.open_lots`, bypassing FIFO/LIFO ordering; gated by `TaxConfig.allow_specific_lot` (default `True`); enables tax-loss harvesting and tax-optimized strategies; shares `_execute_lot_sales()` helper with `sell_asset()`
-- **FeeConfig extensibility (Phase 3)**: `calculate_fee()` now receives keyword-only context (`symbol`, `quantity`, `transaction_type`); Portfolio passes trade context at both buy and sell call sites; subclasses can implement tiered commissions, per-asset fee schedules, or buy/sell-asymmetric pricing; default implementation ignores context for full backward compatibility
+- **FeeConfig extensibility (Phase 3)**: `calculate_fee()` now receives keyword-only context (`symbol`, `quantity`, `transaction_type`, `metadata`); Portfolio passes trade context including the asset's `metadata` dict at both buy and sell call sites; subclasses can implement tiered commissions, metadata-driven per-asset-class fees, or buy/sell-asymmetric pricing; default implementation ignores context for full backward compatibility
 
 See `.claude/review-findings.md` for the full architecture review and action plan.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,12 +132,12 @@ The tax system (`TaxConfig` in `pyfolium/core.py`) uses Pydantic for validation 
 - Per-share cost basis tracking for partial lot sales
 - Tax rates validated to be between 0.0 and 1.0
 
-`TaxConfig` methods (subclassable for custom tax rules):
-- `long_term_cutoff_period(current_period, data_frequency)` → `pd.Period` cutoff
+`TaxConfig` methods (subclassable for custom tax rules); Portfolio passes the asset's `metadata` dict to methods marked with `★`:
+- `long_term_cutoff_period(current_period, data_frequency, *, metadata)` → `pd.Period` cutoff ★
 - `classify_gain(purchase_period, current_period, data_frequency)` → `"short_term"` | `"long_term"`
-- `calculate_tax(short_term_gains, long_term_gains)` → `TaxResult(tax_liability, tax_paid)`
+- `calculate_tax(short_term_gains, long_term_gains, *, metadata)` → `TaxResult(tax_liability, tax_paid)` ★
 - `select_lots(lots)` → filtered and sorted `list[TaxLot]`
-- `effective_cost_basis(lot, all_open_lots)` → `float` (lot's own cost for FIFO/LIFO; weighted average for AVERAGE)
+- `effective_cost_basis(lot, all_open_lots, *, metadata)` → `float` (lot's own cost for FIFO/LIFO; weighted average for AVERAGE) ★
 
 `TaxResult` is a frozen dataclass returned by `calculate_tax`, containing `tax_liability` (added to `tax_owed`) and `tax_paid` (withheld from cash).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Fee calculation (`FeeConfig` in `pyfolium/core.py`) uses Pydantic for validation
 - Percentage-based fee (validated 0.0-1.0)
 - Minimum and maximum fee caps (validated max >= min)
 - Fees incorporated into cost basis for tax calculations
+- `calculate_fee(transaction_value, *, symbol, quantity, transaction_type)` is overridable; Portfolio passes trade context so subclasses can implement tiered commissions, per-asset fees, or buy/sell-asymmetric pricing
 
 ## Testing Patterns
 
@@ -216,6 +217,7 @@ Recent features:
 - **Data loading**: `load_from_csv` and `load_from_dataframe` utilities with explicit `income_column` (defaults to `None`; raises `ValueError` when an explicitly named column is missing) and `min_density` sanity check (default `0.5`) that catches frequency mismatches like monthly data loaded as daily
 - **Comprehensive examples**: 7 usage patterns in examples/backtest_runner_example.py; benchmark in examples/benchmark.py
 - **sell_lot() (P1-5)**: `sell_lot(lot, quantity)` sells from a specific `TaxLot` obtained via `portfolio.open_lots`, bypassing FIFO/LIFO ordering; gated by `TaxConfig.allow_specific_lot` (default `True`); enables tax-loss harvesting and tax-optimized strategies; shares `_execute_lot_sales()` helper with `sell_asset()`
+- **FeeConfig extensibility (Phase 3)**: `calculate_fee()` now receives keyword-only context (`symbol`, `quantity`, `transaction_type`); Portfolio passes trade context at both buy and sell call sites; subclasses can implement tiered commissions, per-asset fee schedules, or buy/sell-asymmetric pricing; default implementation ignores context for full backward compatibility
 
 See `.claude/review-findings.md` for the full architecture review and action plan.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,7 +133,7 @@ The design intent is:
 2. **Users should be able to swap in their own implementations** — a user modeling US wash sale rules, German *Verlustverrechnungstöpfe* (loss offset pools), or a brokerage with tiered commission schedules should be able to provide their own tax or fee class that the Portfolio accepts without modification.
 
 3. **The interface is the contract, not the implementation** — Portfolio depends on *what* a tax/fee config provides (rates, lot ordering, fee calculation), not on *which specific class* provides it. This means:
-   - `FeeConfig.calculate_fee(transaction_value, *, symbol, quantity, transaction_type) → float` is the fee interface. The keyword-only context parameters (`symbol`, `quantity`, `transaction_type`) enable tiered commissions, per-asset fee schedules, and buy/sell-asymmetric pricing in subclasses; the default implementation ignores them.
+   - `FeeConfig.calculate_fee(transaction_value, *, symbol, quantity, transaction_type, metadata) → float` is the fee interface. The keyword-only context parameters enable tiered commissions, metadata-driven per-asset-class fees (`metadata` carries the asset's `Asset.metadata` dict), and buy/sell-asymmetric pricing in subclasses; the default implementation ignores them.
    - `TaxConfig` follows the same pattern: all tax calculation logic lives in the config, not in Portfolio's sell and income paths.
 
 Both FeeConfig and TaxConfig own their calculation logic. FeeConfig has `calculate_fee()` with trade context. TaxConfig provides five methods that Portfolio delegates to:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -136,12 +136,12 @@ The design intent is:
    - `FeeConfig.calculate_fee(transaction_value, *, symbol, quantity, transaction_type, metadata) → float` is the fee interface. The keyword-only context parameters enable tiered commissions, metadata-driven per-asset-class fees (`metadata` carries the asset's `Asset.metadata` dict), and buy/sell-asymmetric pricing in subclasses; the default implementation ignores them.
    - `TaxConfig` follows the same pattern: all tax calculation logic lives in the config, not in Portfolio's sell and income paths.
 
-Both FeeConfig and TaxConfig own their calculation logic. FeeConfig has `calculate_fee()` with trade context. TaxConfig provides five methods that Portfolio delegates to:
-- `long_term_cutoff_period(current_period, data_frequency)` — computes the holding period boundary
+Both FeeConfig and TaxConfig own their calculation logic. FeeConfig has `calculate_fee()` with trade context. TaxConfig provides five methods that Portfolio delegates to — methods that receive per-trade context (including the asset's `metadata` dict) are marked with ★:
+- `long_term_cutoff_period(current_period, data_frequency, *, metadata)` ★ — computes the holding period boundary
 - `classify_gain(purchase_period, current_period, data_frequency)` — returns `"short_term"` or `"long_term"`
-- `calculate_tax(short_term_gains, long_term_gains)` — returns a `TaxResult` with `tax_liability` and `tax_paid`
+- `calculate_tax(short_term_gains, long_term_gains, *, metadata)` ★ — returns a `TaxResult` with `tax_liability` and `tax_paid`
 - `select_lots(lots)` — filters to open lots and sorts by FIFO/LIFO strategy (AVERAGE uses FIFO order)
-- `effective_cost_basis(lot, all_open_lots)` — returns the lot's own cost basis for FIFO/LIFO, or the weighted average across all open lots for AVERAGE
+- `effective_cost_basis(lot, all_open_lots, *, metadata)` ★ — returns the lot's own cost basis for FIFO/LIFO, or the weighted average across all open lots for AVERAGE
 
 TaxConfig also provides `allow_specific_lot` (default `False`), a policy flag that gates whether `sell_lot()` is available. This is a field-level control rather than a method override — it restricts which *API surface* the strategy can use, not how taxes are calculated.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,10 +133,10 @@ The design intent is:
 2. **Users should be able to swap in their own implementations** — a user modeling US wash sale rules, German *Verlustverrechnungstöpfe* (loss offset pools), or a brokerage with tiered commission schedules should be able to provide their own tax or fee class that the Portfolio accepts without modification.
 
 3. **The interface is the contract, not the implementation** — Portfolio depends on *what* a tax/fee config provides (rates, lot ordering, fee calculation), not on *which specific class* provides it. This means:
-   - `FeeConfig.calculate_fee(transaction_value) → float` is the fee interface.
+   - `FeeConfig.calculate_fee(transaction_value, *, symbol, quantity, transaction_type) → float` is the fee interface. The keyword-only context parameters (`symbol`, `quantity`, `transaction_type`) enable tiered commissions, per-asset fee schedules, and buy/sell-asymmetric pricing in subclasses; the default implementation ignores them.
    - `TaxConfig` follows the same pattern: all tax calculation logic lives in the config, not in Portfolio's sell and income paths.
 
-Both FeeConfig and TaxConfig own their calculation logic. FeeConfig has `calculate_fee()`. TaxConfig provides five methods that Portfolio delegates to:
+Both FeeConfig and TaxConfig own their calculation logic. FeeConfig has `calculate_fee()` with trade context. TaxConfig provides five methods that Portfolio delegates to:
 - `long_term_cutoff_period(current_period, data_frequency)` — computes the holding period boundary
 - `classify_gain(purchase_period, current_period, data_frequency)` — returns `"short_term"` or `"long_term"`
 - `calculate_tax(short_term_gains, long_term_gains)` — returns a `TaxResult` with `tax_liability` and `tax_paid`

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ fee_config = FeeConfig(
 portfolio = Portfolio(universe, tax_config=tax_config, fee_config=fee_config)
 ```
 
+Both `TaxConfig` and `FeeConfig` can be subclassed for custom rules. `FeeConfig.calculate_fee()` receives context about the trade — `symbol`, `quantity`, and `transaction_type` (`"buy"` or `"sell"`) — enabling tiered commissions, per-asset fees, or buy/sell-asymmetric pricing:
+
+```python
+class TieredFeeConfig(FeeConfig):
+    def calculate_fee(self, transaction_value, *, symbol=None,
+                      quantity=None, transaction_type=None):
+        if transaction_value <= 1_000:
+            return transaction_value * 0.01
+        return 10 + (transaction_value - 1_000) * 0.005
+```
+
 ## Data Loading
 
 ```python

--- a/README.md
+++ b/README.md
@@ -183,15 +183,17 @@ fee_config = FeeConfig(
 portfolio = Portfolio(universe, tax_config=tax_config, fee_config=fee_config)
 ```
 
-Both `TaxConfig` and `FeeConfig` can be subclassed for custom rules. `FeeConfig.calculate_fee()` receives context about the trade — `symbol`, `quantity`, and `transaction_type` (`"buy"` or `"sell"`) — enabling tiered commissions, per-asset fees, or buy/sell-asymmetric pricing:
+Both `TaxConfig` and `FeeConfig` can be subclassed for custom rules. `FeeConfig.calculate_fee()` receives trade context — including the asset's `metadata` dict — enabling per-asset-class fees, tiered commissions, or buy/sell-asymmetric pricing:
 
 ```python
-class TieredFeeConfig(FeeConfig):
-    def calculate_fee(self, transaction_value, *, symbol=None,
-                      quantity=None, transaction_type=None):
-        if transaction_value <= 1_000:
-            return transaction_value * 0.01
-        return 10 + (transaction_value - 1_000) * 0.005
+Asset(symbol="Anleihe", asset_universe=universe, data=bond_data,
+      price_column="price", metadata={"asset_class": "fixed_income"})
+
+class AssetClassFeeConfig(FeeConfig):
+    def calculate_fee(self, transaction_value, *, metadata=None, **kw):
+        if (metadata or {}).get("asset_class") == "fixed_income":
+            return transaction_value * 0.001  # 0.1% for bonds
+        return transaction_value * 0.01       # 1% for equities
 ```
 
 ## Data Loading

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ fee_config = FeeConfig(
 portfolio = Portfolio(universe, tax_config=tax_config, fee_config=fee_config)
 ```
 
-Both `TaxConfig` and `FeeConfig` can be subclassed for custom rules. `FeeConfig.calculate_fee()` receives trade context — including the asset's `metadata` dict — enabling per-asset-class fees, tiered commissions, or buy/sell-asymmetric pricing:
+Both `TaxConfig` and `FeeConfig` can be subclassed for custom rules. Some of their methods receive trade context — including the asset's `metadata` dict — enabling per-asset-class taxes and fees. Example:
 
 ```python
 Asset(symbol="Anleihe", asset_universe=universe, data=bond_data,

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel, Field, field_validator

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -200,14 +200,29 @@ class FeeConfig(BaseModel):
             )
         return v
 
-    def calculate_fee(self, transaction_value: float) -> float:
+    def calculate_fee(
+        self,
+        transaction_value: float,
+        *,
+        symbol: str | None = None,
+        quantity: float | None = None,
+        transaction_type: str | None = None,
+    ) -> float:
         """Calculate the fee for a given transaction value.
 
+        The default implementation uses fixed + percentage fees with min/max
+        caps. Subclasses can override this method and use the keyword-only
+        context parameters to implement tiered commissions, per-asset fee
+        schedules, or buy/sell-asymmetric pricing.
+
         Args:
-            transaction_value: Absolute value of the transaction
+            transaction_value: Absolute value of the transaction.
+            symbol: Asset symbol being traded.
+            quantity: Number of shares/units in the trade.
+            transaction_type: ``"buy"`` or ``"sell"``.
 
         Returns:
-            Fee amount bounded by minimum_fee and maximum_fee
+            Fee amount bounded by minimum_fee and maximum_fee.
         """
         percentage_based = transaction_value * self.percentage_fee
         total_fee = self.fixed_fee + percentage_based
@@ -969,7 +984,12 @@ class Portfolio:
                 "no price data for this period"
             )
         price = float(raw_price)  # type: ignore[arg-type]
-        fee = self.fee_config.calculate_fee(quantity * price)
+        fee = self.fee_config.calculate_fee(
+            quantity * price,
+            symbol=symbol,
+            quantity=quantity,
+            transaction_type="buy",
+        )
         cost_basis_per_share = price + fee / quantity
         transaction_amount = -(quantity * price + fee)
 
@@ -1116,7 +1136,12 @@ class Portfolio:
                 "no price data for this period"
             )
         price = float(raw_price)  # type: ignore[arg-type]
-        fee = self.fee_config.calculate_fee(total_quantity * price)
+        fee = self.fee_config.calculate_fee(
+            total_quantity * price,
+            symbol=symbol,
+            quantity=total_quantity,
+            transaction_type="sell",
+        )
         sell_basis_per_share = price - fee / total_quantity
 
         long_term_gains = 0.0

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel, Field, field_validator
@@ -58,7 +59,7 @@ class TaxConfig(BaseModel):
         current_period: pd.Period,
         data_frequency: str,
         *,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> pd.Period:
         """Compute the earliest period that qualifies as long-term.
 
@@ -103,7 +104,7 @@ class TaxConfig(BaseModel):
         short_term_gains: float,
         long_term_gains: float,
         *,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> TaxResult:
         """Calculate tax liability and withholding for given gains.
 
@@ -157,7 +158,7 @@ class TaxConfig(BaseModel):
         lot: "TaxLot",
         all_open_lots: list["TaxLot"],
         *,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> float:
         """Return the cost basis per share to use for gain calculation.
 
@@ -219,7 +220,7 @@ class FeeConfig(BaseModel):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> float:
         """Calculate the fee for a given transaction value.
 
@@ -270,7 +271,7 @@ class Asset:
         data: pd.DataFrame,
         price_column: str = "price",
         income_column: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         """Initialize an Asset and register it with the given AssetUniverse.
 

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -207,6 +207,7 @@ class FeeConfig(BaseModel):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> float:
         """Calculate the fee for a given transaction value.
 
@@ -220,6 +221,8 @@ class FeeConfig(BaseModel):
             symbol: Asset symbol being traded.
             quantity: Number of shares/units in the trade.
             transaction_type: ``"buy"`` or ``"sell"``.
+            metadata: The traded asset's metadata dict (from
+                ``Asset.metadata``), or ``None`` if the asset has no metadata.
 
         Returns:
             Fee amount bounded by minimum_fee and maximum_fee.
@@ -989,6 +992,7 @@ class Portfolio:
             symbol=symbol,
             quantity=quantity,
             transaction_type="buy",
+            metadata=self.asset_universe.assets[symbol].metadata,
         )
         cost_basis_per_share = price + fee / quantity
         transaction_amount = -(quantity * price + fee)
@@ -1141,6 +1145,7 @@ class Portfolio:
             symbol=symbol,
             quantity=total_quantity,
             transaction_type="sell",
+            metadata=self.asset_universe.assets[symbol].metadata,
         )
         sell_basis_per_share = price - fee / total_quantity
 

--- a/pyfolium/core.py
+++ b/pyfolium/core.py
@@ -57,6 +57,8 @@ class TaxConfig(BaseModel):
         self,
         current_period: pd.Period,
         data_frequency: str,
+        *,
+        metadata: dict[str, str] | None = None,
     ) -> pd.Period:
         """Compute the earliest period that qualifies as long-term.
 
@@ -65,6 +67,8 @@ class TaxConfig(BaseModel):
         Args:
             current_period: The period of the sale or income event.
             data_frequency: Frequency string (e.g. ``'D'``, ``'M'``).
+            metadata: The traded asset's metadata dict (from
+                ``Asset.metadata``), or ``None`` if the asset has no metadata.
 
         Returns:
             The cutoff period. Lots with ``period <= cutoff`` are long-term.
@@ -98,6 +102,8 @@ class TaxConfig(BaseModel):
         self,
         short_term_gains: float,
         long_term_gains: float,
+        *,
+        metadata: dict[str, str] | None = None,
     ) -> TaxResult:
         """Calculate tax liability and withholding for given gains.
 
@@ -108,6 +114,8 @@ class TaxConfig(BaseModel):
         Args:
             short_term_gains: Total short-term capital gains or income.
             long_term_gains: Total long-term capital gains or income.
+            metadata: The traded asset's metadata dict (from
+                ``Asset.metadata``), or ``None`` if the asset has no metadata.
 
         Returns:
             A :class:`TaxResult` with ``tax_liability`` and ``tax_paid``.
@@ -148,6 +156,8 @@ class TaxConfig(BaseModel):
         self,
         lot: "TaxLot",
         all_open_lots: list["TaxLot"],
+        *,
+        metadata: dict[str, str] | None = None,
     ) -> float:
         """Return the cost basis per share to use for gain calculation.
 
@@ -158,6 +168,8 @@ class TaxConfig(BaseModel):
         Args:
             lot: The specific lot being sold.
             all_open_lots: All open lots for the same symbol.
+            metadata: The traded asset's metadata dict (from
+                ``Asset.metadata``), or ``None`` if the asset has no metadata.
 
         Returns:
             The effective cost basis per share.
@@ -885,12 +897,15 @@ class Portfolio:
         current_holdings = self.holdings.iloc[idx]
         symbols = self.holdings.columns[(current_holdings * income_this_period) != 0]
 
-        cutoff = self.tax_config.long_term_cutoff_period(
-            self.current_period, self.asset_universe.data_frequency
-        )
-
         for symbol in symbols:
             income = income_this_period[symbol]
+            asset_metadata = self.asset_universe.assets[symbol].metadata
+
+            cutoff = self.tax_config.long_term_cutoff_period(
+                self.current_period,
+                self.asset_universe.data_frequency,
+                metadata=asset_metadata,
+            )
 
             lots = self._tax_lots.get(symbol, [])
             total_quantity = sum(lot.quantity_remaining for lot in lots)
@@ -906,7 +921,9 @@ class Portfolio:
                 tax_result = TaxResult(tax_liability=0.0, tax_paid=0.0)
             else:
                 tax_result = self.tax_config.calculate_tax(
-                    short_term_income, long_term_income
+                    short_term_income,
+                    long_term_income,
+                    metadata=asset_metadata,
                 )
 
             transaction_amount = (
@@ -1152,8 +1169,12 @@ class Portfolio:
         long_term_gains = 0.0
         short_term_gains = 0.0
 
+        asset_metadata = self.asset_universe.assets[symbol].metadata
+
         cutoff = self.tax_config.long_term_cutoff_period(
-            self.current_period, self.asset_universe.data_frequency
+            self.current_period,
+            self.asset_universe.data_frequency,
+            metadata=asset_metadata,
         )
 
         # Snapshot open lots before the loop mutates quantity_remaining.
@@ -1161,7 +1182,9 @@ class Portfolio:
         all_open_lots = [ol for ol in self._tax_lots.get(symbol, []) if ol.is_open]
 
         for lot, lot_quantity_sold in lots_to_sell:
-            cost_basis = self.tax_config.effective_cost_basis(lot, all_open_lots)
+            cost_basis = self.tax_config.effective_cost_basis(
+                lot, all_open_lots, metadata=asset_metadata
+            )
             lot_gains = lot_quantity_sold * (sell_basis_per_share - cost_basis)
 
             if lot.period <= cutoff:
@@ -1175,7 +1198,9 @@ class Portfolio:
             )
             self._txn_df_cache = None
 
-        tax_result = self.tax_config.calculate_tax(short_term_gains, long_term_gains)
+        tax_result = self.tax_config.calculate_tax(
+            short_term_gains, long_term_gains, metadata=asset_metadata
+        )
         tax_paid = tax_result.tax_paid
 
         transaction_amount = total_quantity * price - fee - tax_paid

--- a/tests/core/test_fees.py
+++ b/tests/core/test_fees.py
@@ -1,3 +1,14 @@
+import pandas as pd
+import pytest
+
+from pyfolium.core import (
+    Asset,
+    AssetUniverse,
+    FeeConfig,
+    Portfolio,
+)
+
+
 def test_fee_config(fee_config):
     # test the general fee config exists
     assert fee_config.minimum_fee == 5.0
@@ -18,3 +29,227 @@ def test_fee_medium_fee(fee_config):
 
 def test_fee_maximum_fee(fee_config):
     assert fee_config.calculate_fee(1000000.0) == 20.0
+
+
+# --- Phase 3: FeeConfig extensibility tests ---
+
+
+class TieredFeeConfig(FeeConfig):
+    """Tiered commission schedule: lower rates for larger trades."""
+
+    def calculate_fee(
+        self,
+        transaction_value: float,
+        *,
+        symbol: str | None = None,
+        quantity: float | None = None,
+        transaction_type: str | None = None,
+    ) -> float:
+        # Tiered: 1% on first 1000, 0.5% on next 4000, 0.1% above 5000
+        fee = 0.0
+        remaining = transaction_value
+        if remaining <= 0:
+            return 0.0
+        tier1 = min(remaining, 1_000)
+        fee += tier1 * 0.01
+        remaining -= tier1
+        if remaining <= 0:
+            return fee
+        tier2 = min(remaining, 4_000)
+        fee += tier2 * 0.005
+        remaining -= tier2
+        if remaining > 0:
+            fee += remaining * 0.001
+        return fee
+
+
+class PerAssetFeeConfig(FeeConfig):
+    """Different fees per asset symbol."""
+
+    def calculate_fee(
+        self,
+        transaction_value: float,
+        *,
+        symbol: str | None = None,
+        quantity: float | None = None,
+        transaction_type: str | None = None,
+    ) -> float:
+        if symbol == "Bond":
+            return transaction_value * 0.001  # 0.1% for bonds
+        return transaction_value * 0.01  # 1% for everything else
+
+
+class BuySellAsymmetricFeeConfig(FeeConfig):
+    """Different fee rates for buy vs sell."""
+
+    def calculate_fee(
+        self,
+        transaction_value: float,
+        *,
+        symbol: str | None = None,
+        quantity: float | None = None,
+        transaction_type: str | None = None,
+    ) -> float:
+        if transaction_type == "sell":
+            return transaction_value * 0.005  # 0.5% to sell
+        return transaction_value * 0.01  # 1% to buy
+
+
+def test_tiered_fee_small_trade():
+    cfg = TieredFeeConfig()
+    assert cfg.calculate_fee(500) == 500 * 0.01
+
+
+def test_tiered_fee_medium_trade():
+    cfg = TieredFeeConfig()
+    # 1000 * 0.01 + 2000 * 0.005 = 10 + 10 = 20
+    assert cfg.calculate_fee(3_000) == 20.0
+
+
+def test_tiered_fee_large_trade():
+    cfg = TieredFeeConfig()
+    # 1000 * 0.01 + 4000 * 0.005 + 5000 * 0.001 = 10 + 20 + 5 = 35
+    assert cfg.calculate_fee(10_000) == 35.0
+
+
+def test_tiered_fee_zero():
+    cfg = TieredFeeConfig()
+    assert cfg.calculate_fee(0) == 0.0
+
+
+def test_per_asset_fee_uses_symbol():
+    cfg = PerAssetFeeConfig()
+    assert cfg.calculate_fee(10_000, symbol="Bond") == 10.0
+    assert cfg.calculate_fee(10_000, symbol="Stock") == 100.0
+
+
+def test_per_asset_fee_without_symbol_falls_back():
+    cfg = PerAssetFeeConfig()
+    # No symbol → default 1% path
+    assert cfg.calculate_fee(10_000) == 100.0
+
+
+def test_buy_sell_asymmetric_fee():
+    cfg = BuySellAsymmetricFeeConfig()
+    assert cfg.calculate_fee(10_000, transaction_type="buy") == 100.0
+    assert cfg.calculate_fee(10_000, transaction_type="sell") == 50.0
+
+
+def test_buy_sell_asymmetric_fee_no_type():
+    cfg = BuySellAsymmetricFeeConfig()
+    # No transaction_type → defaults to buy rate
+    assert cfg.calculate_fee(10_000) == 100.0
+
+
+def test_default_fee_config_ignores_context():
+    """Default FeeConfig still works when context kwargs are passed."""
+    cfg = FeeConfig(fixed_fee=5.0, percentage_fee=0.01)
+    # Without context
+    assert cfg.calculate_fee(1000) == 15.0
+    # With context — same result, kwargs are ignored
+    assert cfg.calculate_fee(1000, symbol="Stock", quantity=10) == 15.0
+
+
+# --- Integration: Portfolio passes context to FeeConfig ---
+
+
+@pytest.fixture
+def portfolio_with_per_asset_fees():
+    """Portfolio using PerAssetFeeConfig to verify context is passed."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+    Asset(
+        symbol="Stock",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [100.0, 110.0, 120.0]}, index=periods),
+        price_column="price",
+    )
+    Asset(
+        symbol="Bond",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [50.0, 50.0, 50.0]}, index=periods),
+        price_column="price",
+    )
+
+    return Portfolio(
+        asset_universe=universe,
+        fee_config=PerAssetFeeConfig(),
+    )
+
+
+def test_portfolio_buy_passes_symbol_to_fee_config(portfolio_with_per_asset_fees):
+    """Portfolio.buy_asset passes symbol to calculate_fee."""
+    p = portfolio_with_per_asset_fees
+    p.collect_income()
+    p.move_cash(100_000)
+    p.buy_asset("Stock", 10)  # 10 * 100 = 1000, fee = 1% = 10
+    p.buy_asset("Bond", 10)  # 10 * 50 = 500, fee = 0.1% = 0.5
+
+    txns = p.transactions
+    stock_buy = txns[txns["symbol"] == "Stock"].iloc[0]
+    bond_buy = txns[txns["symbol"] == "Bond"].iloc[0]
+
+    assert stock_buy["fee"] == pytest.approx(10.0)
+    assert bond_buy["fee"] == pytest.approx(0.5)
+
+
+def test_portfolio_sell_passes_symbol_to_fee_config(portfolio_with_per_asset_fees):
+    """Portfolio.sell_asset passes symbol to calculate_fee."""
+    p = portfolio_with_per_asset_fees
+    p.collect_income()
+    p.move_cash(100_000)
+    p.buy_asset("Stock", 10)
+    p.buy_asset("Bond", 10)
+    p.update_history()
+    p.advance_period()
+
+    p.collect_income()
+    p.sell_asset("Stock", 5)  # 5 * 110 = 550, fee = 1% = 5.5
+    p.sell_asset("Bond", 5)  # 5 * 50 = 250, fee = 0.1% = 0.25
+
+    txns = p.transactions
+    stock_sell = txns[(txns["symbol"] == "Stock") & (txns["type"] == "sell")].iloc[0]
+    bond_sell = txns[(txns["symbol"] == "Bond") & (txns["type"] == "sell")].iloc[0]
+
+    assert stock_sell["fee"] == pytest.approx(5.5)
+    assert bond_sell["fee"] == pytest.approx(0.25)
+
+
+@pytest.fixture
+def portfolio_with_asymmetric_fees():
+    """Portfolio using BuySellAsymmetricFeeConfig."""
+    universe = AssetUniverse(data_frequency="D")
+    periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+    Asset(
+        symbol="Stock",
+        asset_universe=universe,
+        data=pd.DataFrame({"price": [100.0, 100.0, 100.0]}, index=periods),
+        price_column="price",
+    )
+
+    return Portfolio(
+        asset_universe=universe,
+        fee_config=BuySellAsymmetricFeeConfig(),
+    )
+
+
+def test_portfolio_passes_transaction_type(portfolio_with_asymmetric_fees):
+    """Portfolio passes 'buy' or 'sell' as transaction_type to calculate_fee."""
+    p = portfolio_with_asymmetric_fees
+    p.collect_income()
+    p.move_cash(100_000)
+    p.buy_asset("Stock", 10)  # 10 * 100 = 1000, buy fee = 1% = 10
+    p.update_history()
+    p.advance_period()
+
+    p.collect_income()
+    p.sell_asset("Stock", 5)  # 5 * 100 = 500, sell fee = 0.5% = 2.5
+
+    txns = p.transactions
+    buy_txn = txns[txns["type"] == "buy"].iloc[0]
+    sell_txn = txns[txns["type"] == "sell"].iloc[0]
+
+    assert buy_txn["fee"] == pytest.approx(10.0)
+    assert sell_txn["fee"] == pytest.approx(2.5)

--- a/tests/core/test_fees.py
+++ b/tests/core/test_fees.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pandas as pd
 import pytest
 
@@ -44,7 +46,7 @@ class TieredFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> float:
         # Tiered: 1% on first 1000, 0.5% on next 4000, 0.1% above 5000
         fee = 0.0
@@ -74,7 +76,7 @@ class AssetClassFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> float:
         asset_class = (metadata or {}).get("asset_class", "equity")
         if asset_class == "fixed_income":
@@ -92,7 +94,7 @@ class BuySellAsymmetricFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> float:
         if transaction_type == "sell":
             return transaction_value * 0.005  # 0.5% to sell

--- a/tests/core/test_fees.py
+++ b/tests/core/test_fees.py
@@ -44,6 +44,7 @@ class TieredFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> float:
         # Tiered: 1% on first 1000, 0.5% on next 4000, 0.1% above 5000
         fee = 0.0
@@ -63,8 +64,8 @@ class TieredFeeConfig(FeeConfig):
         return fee
 
 
-class PerAssetFeeConfig(FeeConfig):
-    """Different fees per asset symbol."""
+class AssetClassFeeConfig(FeeConfig):
+    """Fee rates driven by the asset's ``asset_class`` metadata field."""
 
     def calculate_fee(
         self,
@@ -73,10 +74,12 @@ class PerAssetFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> float:
-        if symbol == "Bond":
+        asset_class = (metadata or {}).get("asset_class", "equity")
+        if asset_class == "fixed_income":
             return transaction_value * 0.001  # 0.1% for bonds
-        return transaction_value * 0.01  # 1% for everything else
+        return transaction_value * 0.01  # 1% for equities
 
 
 class BuySellAsymmetricFeeConfig(FeeConfig):
@@ -89,6 +92,7 @@ class BuySellAsymmetricFeeConfig(FeeConfig):
         symbol: str | None = None,
         quantity: float | None = None,
         transaction_type: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> float:
         if transaction_type == "sell":
             return transaction_value * 0.005  # 0.5% to sell
@@ -117,15 +121,17 @@ def test_tiered_fee_zero():
     assert cfg.calculate_fee(0) == 0.0
 
 
-def test_per_asset_fee_uses_symbol():
-    cfg = PerAssetFeeConfig()
-    assert cfg.calculate_fee(10_000, symbol="Bond") == 10.0
-    assert cfg.calculate_fee(10_000, symbol="Stock") == 100.0
+def test_asset_class_fee_uses_metadata():
+    cfg = AssetClassFeeConfig()
+    bond_meta = {"asset_class": "fixed_income"}
+    equity_meta = {"asset_class": "equity"}
+    assert cfg.calculate_fee(10_000, metadata=bond_meta) == 10.0
+    assert cfg.calculate_fee(10_000, metadata=equity_meta) == 100.0
 
 
-def test_per_asset_fee_without_symbol_falls_back():
-    cfg = PerAssetFeeConfig()
-    # No symbol → default 1% path
+def test_asset_class_fee_without_metadata_falls_back():
+    cfg = AssetClassFeeConfig()
+    # No metadata → defaults to equity rate
     assert cfg.calculate_fee(10_000) == 100.0
 
 
@@ -147,72 +153,79 @@ def test_default_fee_config_ignores_context():
     # Without context
     assert cfg.calculate_fee(1000) == 15.0
     # With context — same result, kwargs are ignored
-    assert cfg.calculate_fee(1000, symbol="Stock", quantity=10) == 15.0
+    assert (
+        cfg.calculate_fee(
+            1000, symbol="Aktie", quantity=10, metadata={"asset_class": "equity"}
+        )
+        == 15.0
+    )
 
 
 # --- Integration: Portfolio passes context to FeeConfig ---
 
 
 @pytest.fixture
-def portfolio_with_per_asset_fees():
-    """Portfolio using PerAssetFeeConfig to verify context is passed."""
+def portfolio_with_asset_class_fees():
+    """Portfolio using AssetClassFeeConfig with metadata-tagged assets."""
     universe = AssetUniverse(data_frequency="D")
     periods = pd.period_range("2023-01-01", periods=3, freq="D")
 
     Asset(
-        symbol="Stock",
+        symbol="Aktie",
         asset_universe=universe,
         data=pd.DataFrame({"price": [100.0, 110.0, 120.0]}, index=periods),
         price_column="price",
+        metadata={"asset_class": "equity"},
     )
     Asset(
-        symbol="Bond",
+        symbol="Anleihe",
         asset_universe=universe,
         data=pd.DataFrame({"price": [50.0, 50.0, 50.0]}, index=periods),
         price_column="price",
+        metadata={"asset_class": "fixed_income"},
     )
 
     return Portfolio(
         asset_universe=universe,
-        fee_config=PerAssetFeeConfig(),
+        fee_config=AssetClassFeeConfig(),
     )
 
 
-def test_portfolio_buy_passes_symbol_to_fee_config(portfolio_with_per_asset_fees):
-    """Portfolio.buy_asset passes symbol to calculate_fee."""
-    p = portfolio_with_per_asset_fees
+def test_portfolio_buy_passes_metadata_to_fee_config(portfolio_with_asset_class_fees):
+    """Portfolio.buy_asset passes asset metadata to calculate_fee."""
+    p = portfolio_with_asset_class_fees
     p.collect_income()
     p.move_cash(100_000)
-    p.buy_asset("Stock", 10)  # 10 * 100 = 1000, fee = 1% = 10
-    p.buy_asset("Bond", 10)  # 10 * 50 = 500, fee = 0.1% = 0.5
+    p.buy_asset("Aktie", 10)  # 10 * 100 = 1000, equity fee = 1% = 10
+    p.buy_asset("Anleihe", 10)  # 10 * 50 = 500, fixed_income fee = 0.1% = 0.5
 
     txns = p.transactions
-    stock_buy = txns[txns["symbol"] == "Stock"].iloc[0]
-    bond_buy = txns[txns["symbol"] == "Bond"].iloc[0]
+    equity_buy = txns[txns["symbol"] == "Aktie"].iloc[0]
+    bond_buy = txns[txns["symbol"] == "Anleihe"].iloc[0]
 
-    assert stock_buy["fee"] == pytest.approx(10.0)
+    assert equity_buy["fee"] == pytest.approx(10.0)
     assert bond_buy["fee"] == pytest.approx(0.5)
 
 
-def test_portfolio_sell_passes_symbol_to_fee_config(portfolio_with_per_asset_fees):
-    """Portfolio.sell_asset passes symbol to calculate_fee."""
-    p = portfolio_with_per_asset_fees
+def test_portfolio_sell_passes_metadata_to_fee_config(portfolio_with_asset_class_fees):
+    """Portfolio.sell_asset passes asset metadata to calculate_fee."""
+    p = portfolio_with_asset_class_fees
     p.collect_income()
     p.move_cash(100_000)
-    p.buy_asset("Stock", 10)
-    p.buy_asset("Bond", 10)
+    p.buy_asset("Aktie", 10)
+    p.buy_asset("Anleihe", 10)
     p.update_history()
     p.advance_period()
 
     p.collect_income()
-    p.sell_asset("Stock", 5)  # 5 * 110 = 550, fee = 1% = 5.5
-    p.sell_asset("Bond", 5)  # 5 * 50 = 250, fee = 0.1% = 0.25
+    p.sell_asset("Aktie", 5)  # 5 * 110 = 550, equity fee = 1% = 5.5
+    p.sell_asset("Anleihe", 5)  # 5 * 50 = 250, fixed_income fee = 0.1% = 0.25
 
     txns = p.transactions
-    stock_sell = txns[(txns["symbol"] == "Stock") & (txns["type"] == "sell")].iloc[0]
-    bond_sell = txns[(txns["symbol"] == "Bond") & (txns["type"] == "sell")].iloc[0]
+    equity_sell = txns[(txns["symbol"] == "Aktie") & (txns["type"] == "sell")].iloc[0]
+    bond_sell = txns[(txns["symbol"] == "Anleihe") & (txns["type"] == "sell")].iloc[0]
 
-    assert stock_sell["fee"] == pytest.approx(5.5)
+    assert equity_sell["fee"] == pytest.approx(5.5)
     assert bond_sell["fee"] == pytest.approx(0.25)
 
 

--- a/tests/core/test_taxes.py
+++ b/tests/core/test_taxes.py
@@ -1,7 +1,14 @@
 import pandas as pd
 import pytest
 
-from pyfolium.core import TaxConfig, TaxLot, TaxResult
+from pyfolium.core import (
+    Asset,
+    AssetUniverse,
+    Portfolio,
+    TaxConfig,
+    TaxLot,
+    TaxResult,
+)
 
 
 class TestTaxResult:
@@ -244,6 +251,93 @@ class TestEffectiveCostBasis:
         )
         config = TaxConfig(tax_strategy="AVERAGE")
         assert config.effective_cost_basis(lot, [lot]) == pytest.approx(80.0)
+
+
+class TestTaxConfigMetadata:
+    """TaxConfig methods receive asset metadata from Portfolio."""
+
+    def test_default_methods_accept_metadata(self):
+        """Default TaxConfig methods ignore metadata without error."""
+        config = TaxConfig(withhold_tax=True)
+        meta = {"asset_class": "equity"}
+        cutoff = config.long_term_cutoff_period(
+            pd.Period("2024-06-15", freq="D"), "D", metadata=meta
+        )
+        assert cutoff == pd.Period("2023-06-15", freq="D")
+
+        result = config.calculate_tax(100.0, 200.0, metadata=meta)
+        assert isinstance(result, TaxResult)
+
+        lot = TaxLot(
+            symbol="S",
+            period=pd.Period("2024-01-01", freq="D"),
+            quantity=10.0,
+            quantity_remaining=10.0,
+            cost_basis_per_share=50.0,
+            txn_index=0,
+        )
+        basis = config.effective_cost_basis(lot, [lot], metadata=meta)
+        assert basis == 50.0
+
+    def test_portfolio_passes_metadata_to_calculate_tax(self):
+        """Integration: metadata-aware TaxConfig receives asset metadata."""
+
+        class AssetClassTaxConfig(TaxConfig):
+            def calculate_tax(
+                self, short_term_gains, long_term_gains, *, metadata=None
+            ):
+                asset_class = (metadata or {}).get("asset_class", "equity")
+                rate = 0.10 if asset_class == "fixed_income" else 0.30
+                liability = (short_term_gains + long_term_gains) * rate
+                if liability <= 0:
+                    return TaxResult(tax_liability=0.0, tax_paid=0.0)
+                if self.withhold_tax:
+                    return TaxResult(tax_liability=0.0, tax_paid=liability)
+                return TaxResult(tax_liability=liability, tax_paid=0.0)
+
+        universe = AssetUniverse(data_frequency="D")
+        periods = pd.period_range("2023-01-01", periods=3, freq="D")
+
+        Asset(
+            symbol="Aktie",
+            asset_universe=universe,
+            data=pd.DataFrame({"price": [100.0, 110.0, 120.0]}, index=periods),
+            price_column="price",
+            metadata={"asset_class": "equity"},
+        )
+        Asset(
+            symbol="Anleihe",
+            asset_universe=universe,
+            data=pd.DataFrame({"price": [50.0, 60.0, 70.0]}, index=periods),
+            price_column="price",
+            metadata={"asset_class": "fixed_income"},
+        )
+
+        p = Portfolio(
+            asset_universe=universe,
+            tax_config=AssetClassTaxConfig(withhold_tax=True),
+        )
+        p.collect_income()
+        p.move_cash(100_000)
+        p.buy_asset("Aktie", 10)
+        p.buy_asset("Anleihe", 10)
+        p.update_history()
+        p.advance_period()
+
+        p.collect_income()
+        p.sell_asset("Aktie", 10)  # gain = 10*(110-100) = 100, tax = 30%
+        p.sell_asset("Anleihe", 10)  # gain = 10*(60-50) = 100, tax = 10%
+
+        txns = p.transactions
+        aktie_sell = txns[(txns["symbol"] == "Aktie") & (txns["type"] == "sell")].iloc[
+            0
+        ]
+        anleihe_sell = txns[
+            (txns["symbol"] == "Anleihe") & (txns["type"] == "sell")
+        ].iloc[0]
+
+        assert aktie_sell["tax_paid"] == pytest.approx(30.0)
+        assert anleihe_sell["tax_paid"] == pytest.approx(10.0)
 
 
 def test_tax_config(tax_config):


### PR DESCRIPTION
FeeConfig.calculate_fee() now accepts keyword-only context parameters
(symbol, quantity, transaction_type) enabling subclasses to implement
tiered commissions, per-asset fee schedules, and buy/sell-asymmetric
pricing. Portfolio passes trade context at both buy and sell call sites.
Default implementation ignores context for full backward compatibility.

https://claude.ai/code/session_01DHoKStwxvF56oYt2NLx25h